### PR TITLE
Clean up the Export flow with a proper completion modal

### DIFF
--- a/app/main/ipc-handlers.ts
+++ b/app/main/ipc-handlers.ts
@@ -7,7 +7,6 @@ import { IPC, MergeConfig } from '@/shared/types';
 import { runMerge, abortMerge } from '@/main/merge-engine';
 import { setExporting } from '@/main/export-state';
 import { readFileSync, existsSync } from 'fs';
-import path from 'path';
 
 /**
  * Registers all IPC handlers for font picking, file reading, output selection, and merge execution.
@@ -71,24 +70,12 @@ export function registerIpcHandlers() {
       if (!config.output.familyName?.trim()) {
         return { success: false, error: 'Font Family is Required' };
       }
-      const dirPath = config.export.package.dir;
-      const folderName = path.basename(dirPath);
 
-      // Check if folder already exists and confirm overwrite
-      let overwrite = false;
-      if (existsSync(dirPath)) {
-        const confirm = await dialog.showMessageBox({
-          type: 'warning',
-          message: `\u201C${folderName}\u201D already exists. Replace?`,
-          buttons: ['Replace', 'Cancel'],
-          defaultId: 0,
-          cancelId: 1,
-        });
-        if (confirm.response !== 0) {
-          return { success: false, error: 'Export cancelled' };
-        }
-        overwrite = true;
-      }
+      // PICK_OUTPUT uses showSaveDialog with showOverwriteConfirmation,
+      // so the OS has already asked the user to replace when the target
+      // exists. We just forward overwrite=true to Python when the folder
+      // is present so prepare_output_dir doesn't raise FileExistsError.
+      const overwrite = existsSync(config.export.package.dir);
 
       const mergeConfig: MergeConfig = {
         ...config,

--- a/app/renderer/assets/icons/finished.svg
+++ b/app/renderer/assets/icons/finished.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg id="_レイヤー_1" data-name="レイヤー_1" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 54 54">
+  <!-- Generator: Adobe Illustrator 29.8.5, SVG Export Plug-In . SVG Version: 2.1.1 Build 2)  -->
+  <defs>
+    <style>
+      .st0 {
+        stroke-miterlimit: 10;
+      }
+
+      .st0, .st1 {
+        fill: none;
+        stroke: #73cf35;
+        stroke-width: 2px;
+      }
+
+      .st1 {
+        stroke-linecap: round;
+        stroke-linejoin: round;
+      }
+    </style>
+  </defs>
+  <circle class="st0" cx="27.0526316" cy="26.9736842" r="25.4074003"/>
+  <polyline class="st1" points="16.4832805 25.5428991 24.5102949 34.6745106 38.9184148 20.0610621"/>
+</svg>

--- a/app/renderer/components/ExportCompleteModal.tsx
+++ b/app/renderer/components/ExportCompleteModal.tsx
@@ -1,0 +1,60 @@
+/**
+ * @fileoverview Modal shown after a successful export. Pure acknowledgement —
+ * Reveal-in-Finder is not offered here because the hand-off already happens
+ * via the native Save panel's location, and adding it would compete with the
+ * Close action for attention.
+ */
+
+import React from 'react';
+import { Dialog, DialogContent, DialogTitle } from '@/renderer/components/ui/dialog';
+import { Button } from '@/renderer/components/ui/button';
+import { useMergeStore } from '@/renderer/stores/mergeStore';
+import { computeStyleName } from '@/shared/constants';
+import finishedSvg from '@/renderer/assets/icons/finished.svg';
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+/**
+ * Completion confirmation modal shown after a successful font export. Uses
+ * the finished.svg check mark plus the family + style in the same typography
+ * as the Metadata modal, followed by a single muted Close button.
+ */
+export const ExportCompleteModal: React.FC<Props> = ({ open, onOpenChange }) => {
+  const { familyName, fontWeight, fontItalic, fontWidth } = useMergeStore();
+  const styleName = computeStyleName(fontWeight, fontItalic, fontWidth);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-[280px] mx-auto p-[18px]" hideCloseButton>
+        <div className="flex flex-col items-center text-center">
+          <img
+            src={finishedSvg}
+            alt=""
+            width={54}
+            height={54}
+            draggable={false}
+            className="mb-4 mt-2"
+          />
+
+          <DialogTitle className="text-[18px] font-semibold">
+            {familyName || 'Untitled'}
+            <span className="text-muted-foreground font-normal ml-2">{styleName}</span>
+          </DialogTitle>
+
+          <div className="text-[13px] text-green-500 mt-1 mb-8">Export Finished</div>
+
+          <Button
+            variant="secondary"
+            onClick={() => onOpenChange(false)}
+            className="w-full h-[40px] text-base shadow-none"
+          >
+            Close
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/app/renderer/components/ExportPanel.tsx
+++ b/app/renderer/components/ExportPanel.tsx
@@ -7,6 +7,7 @@ import { useMergeStore } from '@/renderer/stores/mergeStore';
 import { useMerge } from '@/renderer/hooks/useMerge';
 import { Button } from '@/renderer/components/ui/button';
 import { ExportMetadataModal } from '@/renderer/components/ExportMetadataModal';
+import { ExportCompleteModal } from '@/renderer/components/ExportCompleteModal';
 import { cn } from '@/renderer/lib/utils';
 import { WEIGHT_MAP, DONE_DISPLAY_MS, ERROR_DISPLAY_MS } from '@/shared/constants';
 
@@ -29,6 +30,15 @@ export const ExportPanel: React.FC = () => {
   const { startMerge, isMerging } = useMerge();
   const [isHoveringStop, setIsHoveringStop] = useState(false);
   const [metadataOpen, setMetadataOpen] = useState(false);
+  const [completeOpen, setCompleteOpen] = useState(false);
+
+  /**
+   * Kicks off the merge and opens the completion modal when it succeeds.
+   */
+  async function handleExport() {
+    const exportedPath = await startMerge();
+    if (exportedPath) setCompleteOpen(true);
+  }
 
   const hasValidName = familyName.trim().length > 0;
   const canMerge = baseFont && !isMerging && hasValidName;
@@ -178,7 +188,7 @@ export const ExportPanel: React.FC = () => {
           </Button>
         ) : (
           <Button
-            onClick={startMerge}
+            onClick={handleExport}
             disabled={!canMerge}
             size="lg"
             className="rounded-md w-[100px] @[36rem]:w-[130px] h-[38px] shrink-0 text-base"
@@ -188,6 +198,7 @@ export const ExportPanel: React.FC = () => {
         )}
 
         <ExportMetadataModal open={metadataOpen} onOpenChange={setMetadataOpen} />
+        <ExportCompleteModal open={completeOpen} onOpenChange={setCompleteOpen} />
       </div>
     </div>
   );

--- a/app/renderer/components/ui/dialog.tsx
+++ b/app/renderer/components/ui/dialog.tsx
@@ -32,13 +32,19 @@ const DialogOverlay = React.forwardRef<
 ));
 DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
+interface DialogContentProps
+  extends React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> {
+  /** When true, omit the floating close (×) button outside the dialog box. */
+  hideCloseButton?: boolean;
+}
+
 /**
  * The main content container for a dialog, rendered in a portal with an overlay backdrop.
  */
 const DialogContent = React.forwardRef<
   React.ComponentRef<typeof DialogPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, children, onPointerDownOutside, ...props }, ref) => (
+  DialogContentProps
+>(({ className, children, onPointerDownOutside, hideCloseButton, ...props }, ref) => (
   <DialogPortal>
     <DialogOverlay />
     <div className="fixed inset-0 z-[60] flex items-center justify-center p-4 pointer-events-none">
@@ -58,13 +64,15 @@ const DialogContent = React.forwardRef<
         >
           {children}
         </div>
-        <DialogPrimitive.Close
-          aria-label="Close"
-          className="absolute -right-[40px] top-0 flex h-[30px] w-[30px] cursor-pointer items-center justify-center rounded-full bg-white pointer-events-auto"
-          style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
-        >
-          <img src={modalCloseSvg} alt="" width={30} height={30} draggable={false} />
-        </DialogPrimitive.Close>
+        {!hideCloseButton && (
+          <DialogPrimitive.Close
+            aria-label="Close"
+            className="absolute -right-[40px] top-0 flex h-[30px] w-[30px] cursor-pointer items-center justify-center rounded-full bg-white pointer-events-auto"
+            style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
+          >
+            <img src={modalCloseSvg} alt="" width={30} height={30} draggable={false} />
+          </DialogPrimitive.Close>
+        )}
       </DialogPrimitive.Content>
     </div>
   </DialogPortal>

--- a/app/renderer/hooks/useMerge.ts
+++ b/app/renderer/hooks/useMerge.ts
@@ -35,8 +35,9 @@ export function useMerge() {
   /**
    * Initiates the font merge process by reading current store state, prompting for an output path,
    * and sending the merge configuration to the main process via IPC.
+   * @returns The absolute path of the exported font on success, otherwise null.
    */
-  async function startMerge() {
+  async function startMerge(): Promise<string | null> {
     const {
       latinFont, baseFont, familyName,
       fontWeight, fontItalic, fontWidth,
@@ -45,13 +46,13 @@ export function useMerge() {
 
     if (!baseFont) {
       window.electronAPI.showAlert?.('No base font', 'Please load a base font first.');
-      return;
+      return null;
     }
 
     const fileStyle = computeFileStyleName(fontWeight, fontItalic, fontWidth);
     const defaultFolderName = `${familyName.replace(/\s+/g, '')}-${fileStyle}`;
     const chosenPath = await window.electronAPI.pickOutput(defaultFolderName);
-    if (!chosenPath) return;
+    if (!chosenPath) return null;
 
     // Show the spinner immediately. The first "real" progress event only
     // arrives after the PyInstaller binary cold-starts and fontTools imports,
@@ -85,8 +86,9 @@ export function useMerge() {
         setMergeProgress({ stage: 'error', percent: 0, message: result.error });
       }
       setIsMerging(false);
-      return;
+      return null;
     }
+    return result.path ?? null;
   }
 
   return { startMerge, isMerging };


### PR DESCRIPTION
## Summary
- Drops the redundant "Replace?" confirmation when exporting — the OS already
  asks via `showSaveDialog` with `showOverwriteConfirmation`, so the Electron
  warning was a second click for the same decision.
- Adds a small completion modal (green check + family/style + muted Close)
  that fires when an export succeeds, so the hand-off is unambiguous even on
  large displays where the inline status is easy to miss.
- Adds a `hideCloseButton` prop to `DialogContent` so the completion surface
  can read as a single confirmation step without the floating × icon.

## Test plan
- [ ] Run a real export — the OS Save dialog still appears, the "Replace" Electron prompt no longer does, and the completion modal shows the current family + style.
- [ ] Click **Close**: the modal dismisses and state returns to idle.
- [ ] Confirm the inline "Export complete" status under the progress bar still displays (kept for a quick glance).
- [ ] Existing modals (Metadata, Font Info) still show their floating × close button — i.e. `hideCloseButton` is opt-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)