### PR TITLE
Narrow Type 4 ligature classifier to input glyphs only

### DIFF
--- a/python/merge_fonts.py
+++ b/python/merge_fonts.py
@@ -1158,24 +1158,21 @@ def _collect_lookup_glyphs(lookup) -> set:
                     glyph_names.update(cov.glyphs)
             if hasattr(st, 'ligatures') and st.ligatures:
                 glyph_names.update(st.ligatures.keys())
-                # Type 4 ligatures stash the trailing input glyphs in
-                # `Component` and the output in `LigGlyph`. Walk them too:
-                # the keys (= first glyph) alone would let `_classify_lookup`
-                # mark a JP `f i → fi` ligature as `latin` (because `f` lives
-                # in Latin), which then strips JP-side ligatures from the
-                # merged font.
+                # Type 4 ligatures stash the trailing INPUT glyphs in
+                # `Component`. Walk them too so `_classify_lookup` sees the
+                # full input set. We deliberately do NOT add `LigGlyph`
+                # (the output): including the output would let a JP-designed
+                # `f i → JP-fi` ligature look like a `mixed` lookup just
+                # because the output glyph is JP-side, even though every
+                # input is Latin. That is the textbook "subordinate Latin
+                # liga" the merge engine wants to drop.
                 for lig_list in st.ligatures.values():
                     if not lig_list:
                         continue
                     for lig in lig_list:
-                        for attr in ('Component', 'LigGlyph'):
-                            val = getattr(lig, attr, None)
-                            if val is None:
-                                continue
-                            if isinstance(val, (list, tuple)):
-                                glyph_names.update(val)
-                            else:
-                                glyph_names.add(val)
+                        comp = getattr(lig, 'Component', None)
+                        if comp:
+                            glyph_names.update(comp)
             if hasattr(st, 'mapping') and st.mapping:
                 glyph_names.update(st.mapping.keys())
             if hasattr(st, 'alternates') and st.alternates:


### PR DESCRIPTION
_[日本語版](#概要) ↓_

This PR was created and developed with support from Claude Opus 4.7.

## Summary

Hot-fix for a regression introduced by PR #9.

PR #9's commit `8531196` ("Fix Type 4 ligature classification") extended `_collect_lookup_glyphs` to walk **both** `Component` (input) and `LigGlyph` (output) for Type 4 ligature subtables. Walking `LigGlyph` is too broad: a JP-side ligature like `f i → JP-fi` then looks `mixed` to `_classify_lookup` only because the _output_ glyph lives on the JP side, even though every _input_ glyph is Latin. The merge engine keeps that subordinate Latin liga in the merged font instead of dropping it.

This regressed two tests that were passing before PR #9:

- `test_japanese_subordinate_liga_removed`
- `test_no_jp_subordinate_liga_in_latin_script`

Fix: walk `Component` only — the original intent of the classifier widening — so the classifier sees the full _input_ set without being confused by the output glyph.

## Why the original PR #9 change was needed

The bug PR #9 was trying to solve is real: looking only at `st.ligatures.keys()` (= the first input glyph) misclassifies a JP `f i → fi` ligature as `latin` because the dict key `f` lives in the Latin range, which then strips JP-side ligatures from the merged font. Walking `Component` (the trailing input glyphs) fixes that — adding `LigGlyph` was the over-reach.

## Fix

`python/merge_fonts.py` — `_collect_lookup_glyphs`:

```python
# before (PR #9, too broad)
for attr in ('Component', 'LigGlyph'):
    val = getattr(lig, attr, None)
    ...

# after (this PR, narrowed)
comp = getattr(lig, 'Component', None)
if comp:
    glyph_names.update(comp)
```

## Verification

- `npm test` — 186 passed, 1 skipped (same intentional skip as before)
- The two regression tests pass against `Inter` × `NotoSansJP` (fixtures already added in PR #9):
  - `test_japanese_subordinate_liga_removed`
  - `test_no_jp_subordinate_liga_in_latin_script`

---

※ 本 PR の作成と、それに伴う修正は Claude Opus 4.7 の支援のもと行われました。

## 概要

PR #9 で入った回帰の hot-fix。

PR #9 のコミット `8531196`（"Fix Type 4 ligature classification"）で `_collect_lookup_glyphs` を Type 4 リガチャの `Component`（入力）と `LigGlyph`（出力）の **両方** を見るように拡張したが、`LigGlyph` まで含めるのは過剰。JP 側の `f i → JP-fi` のようなリガチャが、入力グリフは全て Latin なのに _出力_ グリフが JP 側にあるという理由で `_classify_lookup` から `mixed` と判定され、本来削除されるべき subordinate Latin liga が merged フォントに残ってしまう。

これにより PR #9 以前は通っていた以下 2 つのテストが回帰：

- `test_japanese_subordinate_liga_removed`
- `test_no_jp_subordinate_liga_in_latin_script`

修正方針：`Component`（入力）のみを walk する。これが分類器拡張の本来の意図で、出力グリフに引きずられずに _入力_ セット全体を見られる。

## なぜ PR #9 の変更自体は必要だったか

PR #9 が解決しようとしたバグは実在する：`st.ligatures.keys()`（= 最初の入力グリフ）だけを見ると、JP の `f i → fi` リガチャが、dict キーの `f` が Latin 範囲にあるという理由で `latin` と誤分類され、JP 側のリガチャが merged フォントから削除されてしまう。`Component`（後続の入力グリフ）を walk することでこのバグは解消する。`LigGlyph` まで追加してしまったのが過剰。

## 修正内容

`python/merge_fonts.py` — `_collect_lookup_glyphs`:

```python
# before（PR #9、過剰）
for attr in ('Component', 'LigGlyph'):
    val = getattr(lig, attr, None)
    ...

# after（このPR、絞り込み）
comp = getattr(lig, 'Component', None)
if comp:
    glyph_names.update(comp)
```

## 動作確認

- `npm test` — 186 passed, 1 skipped（従来と同じ意図的 skip）
- 回帰テスト 2 件（PR #9 で既に追加されていた `Inter` × `NotoSansJP` フィクスチャを使用）が通過：
  - `test_japanese_subordinate_liga_removed`
  - `test_no_jp_subordinate_liga_in_latin_script`
