### PR TITLE
Preserve Latin features in named LangSys merges

### DIFF
--- a/python/merge_fonts.py
+++ b/python/merge_fonts.py
@@ -1985,9 +1985,15 @@ def _merge_ot_table_v2(lat_table, jp_table, lat_font, jp_font, merged,
         for lang_tag in sorted(lang_sys_tags):
             new_lsr = otTables.LangSysRecord()
             new_lsr.LangSysTag = lang_tag
+            # If only one input defines a named LangSys, the other input's
+            # DefaultLangSys is still active for that language before merge.
+            # Preserve that effective feature set so the new named record does
+            # not shadow the missing side's default features.
+            jp_lang_sys = jp_lang_map.get(lang_tag, jp_default)
+            lat_lang_sys = lat_lang_map.get(lang_tag, lat_default)
             new_lsr.LangSys = _build_lang_sys(
-                jp_lang_map.get(lang_tag),
-                lat_lang_map.get(lang_tag),
+                jp_lang_sys,
+                lat_lang_sys,
                 script_tag, table_tag,
                 jp_feat_index_map, lat_feat_index_map,
                 jp_feature_records, lat_feature_records)

--- a/python/tests/test_glyph_data.py
+++ b/python/tests/test_glyph_data.py
@@ -1728,6 +1728,78 @@ class TestSameTagFeatures:
 
 
 # ---------------------------------------------------------------------------
+# Named LangSys default fallback (Issue #12)
+# ---------------------------------------------------------------------------
+
+class TestNamedLangSysDefaultFallback:
+    """Named LangSys records must preserve the other side's default features.
+
+    If the merged font creates `latn/JAN` from the JP base but the Latin sub
+    font only has `latn/dflt`, HarfBuzz selects `latn/JAN` for Japanese text
+    and never consults `latn/dflt`. The named record therefore needs the
+    Latin default feature set folded in.
+    """
+
+    @staticmethod
+    def _gsub_feature_tags(font, script_tag, lang_sys_tag=None):
+        gsub = font["GSUB"].table
+        features = gsub.FeatureList.FeatureRecord
+        for sr in gsub.ScriptList.ScriptRecord:
+            if sr.ScriptTag != script_tag:
+                continue
+            if lang_sys_tag is None:
+                lang_sys = sr.Script.DefaultLangSys
+            else:
+                lang_sys = None
+                for lsr in (sr.Script.LangSysRecord or []):
+                    if lsr.LangSysTag == lang_sys_tag:
+                        lang_sys = lsr.LangSys
+                        break
+            if lang_sys is None:
+                pytest.fail(f"{script_tag}/{lang_sys_tag or 'dflt'} missing")
+            return {
+                features[i].FeatureTag
+                for i in (lang_sys.FeatureIndex or [])
+            }
+        pytest.fail(f"{script_tag} script missing")
+
+    def test_latn_jan_keeps_latin_default_features(self):
+        """Noto's `latn/JAN` must not shadow Inter's `latn/dflt` GSUB."""
+        m = _merge()
+        tags = self._gsub_feature_tags(m, "latn", "JAN ")
+
+        assert {"calt", "case", "frac", "tnum", "ss01", "zero"} <= tags
+        assert "locl" in tags
+
+    def test_latin_named_langsys_keeps_jp_default_features(self):
+        """The fallback is symmetric when only the Latin side has a locale."""
+        out = tempfile.mktemp(suffix=".ttf")
+        config = {
+            "subFont": {
+                "path": TIKTOK_SANS,
+                "scale": 1.0,
+                "baselineOffset": 0,
+                "axes": [],
+            },
+            "baseFont": {
+                "path": JP_VAR,
+                "scale": 1.0,
+                "baselineOffset": 0,
+                "axes": [{"tag": "wght", "currentValue": 400}],
+            },
+            "output": {"familyName": "TestNamedLangSys"},
+            "export": {"path": {"font": out}},
+        }
+        mf.merge_fonts(config)
+        m = TTFont(out)
+        os.remove(out)
+
+        tags = self._gsub_feature_tags(m, "latn", "CAT ")
+        assert "calt" in tags
+        assert "fwid" in tags
+
+
+# ---------------------------------------------------------------------------
 # maxp recalc after merge (Issue #2 #8)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
This PR was created and developed with support from Codex GPT 5.5.

## Summary

Fixes #12.

This is a focused follow-up to #11. PR #11 fixed several Latin layout reachability issues around default `latn` feature merging, duplicate feature tags, kerning, ligatures, and combining-mark composition. However, named LangSys records such as `latn/JAN` were still built only from records explicitly present on each input font.

When the base font defines `latn/JAN` and the Latin sub font only defines `latn/dflt`, HarfBuzz selects `latn/JAN` for Japanese-language text and does not fall back to the merged `latn/dflt`. That meant the named record shadowed all Latin default features from the sub font, making tags such as `calt`, `case`, `frac`, `tnum`, `ss01`, and `zero` unavailable under `lang="ja"`.

## Fix

- When merging named LangSys records, each side now falls back to that side's `DefaultLangSys` if it does not explicitly define the named language.
- This preserves the effective per-language feature set from both inputs, instead of unioning only explicitly named LangSys records.
- Added regression coverage for `latn/JAN` preserving Inter's Latin default GSUB features when merged into Noto Sans JP.
- Added a symmetric regression case where a Latin-only named locale (`latn/CAT`) still keeps JP default features from the base font.

## Verification

- `python3 -m pytest python/tests/test_glyph_data.py::TestNamedLangSysDefaultFallback -q` — 2 passed
- `python3 -m pytest python/tests/test_glyph_data.py::TestSameTagFeatures python/tests/test_glyph_data.py::TestInterDligChainContext -q` — 9 passed
- `python3 -m pytest python/tests/test_glyph_data.py::TestLatinLigaturePreservation python/tests/test_glyph_data.py::TestFeaturePreservation python/tests/test_filter_subordinate_lookups.py -q` — 43 passed, 1 skipped
- `npm test` — 290 passed, 1 skipped
