### PR TITLE
Fix Adobe CJK GPOS kerning compatibility

### DIFF
--- a/docs/ARCHITECTURE.ja.md
+++ b/docs/ARCHITECTURE.ja.md
@@ -157,6 +157,29 @@ Latin で始まる merged slot は、すでに Latin フォントのアウトラ
 字幅モデルに置き換わっているため、JP 由来の Latin-first カーニングは
 一部だけ残さず従属データとしてまとめて捨てる。
 
+### Adobe 互換の `kern` feature 形状
+
+merged GPOS の `kern` feature は、JP と Latin の feature record を分けて
+残すのではなく、ベースフォントの元構造に寄せて 1 本化する。Noto Sans JP は
+`DFLT` / `hani` / `kana` / `latn` の各 script から同じ `kern` feature record
+を参照しており、Adobe アプリは日本語のメトリクスカーニングでこの形を前提に
+しているように見える。merged font に重複した `kern` record が残ったり、
+`latn` が Latin 側の kern lookup だけを指したりすると、Illustrator では
+`palt` は効くのに `す。` のような CJK ペアカーニングだけ無視されることがある。
+
+GPOS merge 時は、JP と Latin の `kern` feature record を 1 つの merged
+feature record に畳み込む。JP/base の PairPos lookup は先頭に残し、事前に
+Latin-first エントリを除去してあるため、CJK ペアはベースフォントの値を保ち、
+Latin ペアは後続の Latin lookup に fall through して積算なしで適用される。
+元々どちらかの `kern` を参照していた script/LangSys は、すべてこの 1 本の
+merged record を参照する。
+
+一度フォントを書き出したあと、`_save_with_adobe_kern_compat` は出力を読み戻し、
+非 Latin の `kern` PairPos が GPOS ExtensionPos (`LookupType 9`) の背後に
+隠れていないか確認する。該当する場合は fontTools の HarfBuzz repacker を
+無効にして再保存し、CJK PairPos を direct `LookupType 2` として維持する。
+これは Adobe が安定して処理できる元フォント側の構造に合わせるためである。
+
 ### 欧文リガチャの保持
 
 Pan-CJK ベース書体は `dlig` / `liga` の lookup に Latin 入力のリガチャ

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -160,6 +160,29 @@ Latin font's outline and spacing model, so JP-origin Latin-first kerning is
 treated as subordinate and discarded wholesale rather than partially kept
 for JP-only second glyphs.
 
+### Adobe-Compatible `kern` Feature Shape
+
+The merged GPOS `kern` feature intentionally follows the base font's source
+shape rather than keeping separate JP and Latin feature records. Noto Sans JP
+exposes one `kern` feature record across `DFLT` / `hani` / `kana` / `latn`;
+Adobe apps appear to rely on that shape for Japanese metrics kerning. If the
+merged font exposes duplicate `kern` records, or if `latn` only points at the
+Latin source's kern lookups, Illustrator can apply `palt` while ignoring CJK
+pair kerning such as `す。`.
+
+During GPOS merge, JP and Latin `kern` feature records are folded into one
+merged feature record. The JP/base PairPos lookup stays first and has already
+had Latin-first entries stripped, so CJK pairs keep the base font's values
+while Latin pairs fall through to the appended Latin lookups without stacking.
+Every script/LangSys that previously referenced either side's `kern` maps to
+that single merged record.
+
+After writing the font once, `_save_with_adobe_kern_compat` reloads the output
+and checks whether a non-Latin `kern` PairPos was hidden behind GPOS
+ExtensionPos (`LookupType 9`). If so, it disables fontTools' HarfBuzz repacker
+and saves again so the CJK PairPos remains a direct `LookupType 2`, matching
+the source font structure Adobe handles reliably.
+
 ### Latin Ligature Preservation
 
 Pan-CJK base fonts pack Latin-input ligatures into the same `dlig` / `liga`

--- a/python/merge_fonts.py
+++ b/python/merge_fonts.py
@@ -32,6 +32,7 @@ import sys
 
 from fontTools.misc.timeTools import timestampNow
 from fontTools.ttLib import TTFont
+from fontTools.ttLib.tables.otBase import USE_HARFBUZZ_REPACKER
 from fontTools.pens.pointPen import SegmentToPointPen
 from fontTools.pens.recordingPen import RecordingPen
 from fontTools.pens.ttGlyphPen import TTGlyphPen
@@ -45,6 +46,59 @@ def progress(stage: str, percent: int, message: str):
         "percent": percent,
         "message": message,
     }), file=sys.stderr, flush=True)
+
+
+def _disable_harfbuzz_repacker(font: TTFont):
+    """Keep final GSUB/GPOS serialization in fontTools' pure Python path.
+
+    hb.repack can preserve valid tables, but for large merged GPOS tables it
+    may emit CJK kern PairPos lookups behind ExtensionPos. Adobe apps appear
+    not to apply those CJK metrics kern pairs, so prefer direct PairPos output.
+    """
+    font.cfg[USE_HARFBUZZ_REPACKER] = False
+
+
+def _has_extension_non_latin_kern(font: TTFont, lat_glyph_names: set) -> bool:
+    """Return True when a saved font wraps non-Latin kern PairPos in ExtensionPos."""
+    gpos = font.get("GPOS")
+    if not gpos or not getattr(gpos, "table", None):
+        return False
+    table = gpos.table
+    if not table.LookupList or not table.FeatureList:
+        return False
+
+    for feature_record in table.FeatureList.FeatureRecord:
+        if feature_record.FeatureTag != "kern":
+            continue
+        for lookup_index in feature_record.Feature.LookupListIndex:
+            lookup = table.LookupList.Lookup[lookup_index]
+            if lookup.LookupType != 9:
+                continue
+            for subtable in lookup.SubTable:
+                if getattr(subtable, "ExtensionLookupType", None) != 2:
+                    continue
+                pairpos = getattr(subtable, "ExtSubTable", None)
+                coverage = getattr(pairpos, "Coverage", None)
+                glyphs = getattr(coverage, "glyphs", None) if coverage else None
+                if glyphs and any(g not in lat_glyph_names for g in glyphs):
+                    return True
+    return False
+
+
+def _save_with_adobe_kern_compat(font: TTFont, output_path: str,
+                                 lat_glyph_names: set):
+    """Save normally, then fall back only if hb.repack hides CJK kern."""
+    font.save(output_path)
+
+    saved = TTFont(output_path)
+    try:
+        needs_fallback = _has_extension_non_latin_kern(saved, lat_glyph_names)
+    finally:
+        saved.close()
+
+    if needs_fallback:
+        _disable_harfbuzz_repacker(font)
+        font.save(output_path)
 
 
 # ---------------------------------------------------------------------------
@@ -1894,17 +1948,39 @@ def _merge_ot_table_v2(lat_table, jp_table, lat_font, jp_font, merged,
     # Collect JP features (with remapped lookup indices, dropping empty ones)
     jp_features = []  # list of (tag, Feature object, source='jp')
     jp_feat_index_map = {}  # old JP feature index → new merged feature index
+    merged_gpos_kern_index = None
+
+    def _merge_lookup_indices_into_feature(feature_index, lookup_indices):
+        if feature_index < len(jp_features):
+            feature = jp_features[feature_index][1].Feature
+        else:
+            feature = lat_features[feature_index - len(jp_features)][1].Feature
+        seen = set(feature.LookupListIndex or [])
+        for lookup_index in lookup_indices:
+            if lookup_index not in seen:
+                feature.LookupListIndex.append(lookup_index)
+                seen.add(lookup_index)
+        feature.LookupCount = len(feature.LookupListIndex)
+
     if jp_ot.FeatureList:
         for old_idx, feat_rec in enumerate(jp_ot.FeatureList.FeatureRecord):
             new_indices = [jp_remap[i] for i in feat_rec.Feature.LookupListIndex
                            if i in jp_remap]
             if new_indices:
+                if table_tag == 'GPOS' and feat_rec.FeatureTag == 'kern' \
+                        and merged_gpos_kern_index is not None:
+                    _merge_lookup_indices_into_feature(
+                        merged_gpos_kern_index, new_indices)
+                    jp_feat_index_map[old_idx] = merged_gpos_kern_index
+                    continue
                 new_feat = copy.deepcopy(feat_rec)
                 new_feat.Feature.LookupListIndex = new_indices
                 new_feat.Feature.LookupCount = len(new_indices)
                 new_merged_idx = len(jp_features)
                 jp_feat_index_map[old_idx] = new_merged_idx
                 jp_features.append((feat_rec.FeatureTag, new_feat, 'jp'))
+                if table_tag == 'GPOS' and feat_rec.FeatureTag == 'kern':
+                    merged_gpos_kern_index = new_merged_idx
 
     # Collect EN features (with offset lookup indices)
     lat_features = []  # list of (tag, Feature object, source='en')
@@ -1916,6 +1992,12 @@ def _merge_ot_table_v2(lat_table, jp_table, lat_font, jp_font, merged,
                 i + lat_offset for i in new_feat.Feature.LookupListIndex
             ]
             new_feat.Feature.LookupCount = len(new_feat.Feature.LookupListIndex)
+            if table_tag == 'GPOS' and feat_rec.FeatureTag == 'kern' \
+                    and merged_gpos_kern_index is not None:
+                _merge_lookup_indices_into_feature(
+                    merged_gpos_kern_index, new_feat.Feature.LookupListIndex)
+                lat_feat_index_map[old_idx] = merged_gpos_kern_index
+                continue
             # Mark this record so the later UINameID-collision remap in
             # reconcile_tables only touches Latin-derived FeatureParams,
             # not the base font's ones that happen to share a nameID value.
@@ -1923,6 +2005,8 @@ def _merge_ot_table_v2(lat_table, jp_table, lat_font, jp_font, merged,
             new_merged_idx = len(jp_features) + len(lat_features)
             lat_feat_index_map[old_idx] = new_merged_idx
             lat_features.append((feat_rec.FeatureTag, new_feat, 'en'))
+            if table_tag == 'GPOS' and feat_rec.FeatureTag == 'kern':
+                merged_gpos_kern_index = new_merged_idx
 
     # Merged feature list: JP features first, then EN features
     all_features = jp_features + lat_features
@@ -3408,7 +3492,12 @@ def merge_fonts(config: dict) -> str:
     # merge renumbered glyph IDs.
     _resort_lookup_coverages(merged)
 
-    merged.save(output_path)
+    output_lat_glyph_names = set()
+    if lat_font:
+        output_lat_glyph_names = {
+            lat_to_merged_name.get(g, g) for g in lat_font.getGlyphOrder()
+        }
+    _save_with_adobe_kern_compat(merged, output_path, output_lat_glyph_names)
 
     # Step 14: Write WOFF2
     woff2_out = paths.get("woff2")

--- a/python/tests/test_glyph_data.py
+++ b/python/tests/test_glyph_data.py
@@ -971,16 +971,19 @@ class TestFeaturePreservation:
                                             f"Lookup {i}: nested chaining ref {slr.LookupListIndex} >= total {total}"
 
     def test_base_kern_preserved_in_dflt_script(self):
-        """CJK kern (e.g. す。) from base font is accessible from DFLT script."""
-        if not os.path.exists(JP_FULL_VAR):
-            pytest.skip("NotoSansJP-VariableFont_wght.ttf not found")
+        """CJK kern stays direct PairPos and accessible from DFLT script."""
+        if not os.path.exists(JP_FULL_VAR) or not os.path.exists(EN_FULL):
+            pytest.skip("Full Inter or Noto Sans JP variable fixture not found")
         out = tempfile.mktemp(suffix=".ttf")
         config = {
             "subFont": {
-                "path": EN_CFF,
+                "path": EN_FULL,
                 "scale": 1.0,
                 "baselineOffset": 0,
-                "axes": [],
+                "axes": [
+                    {"tag": "opsz", "currentValue": 14},
+                    {"tag": "wght", "currentValue": 400},
+                ],
             },
             "baseFont": {
                 "path": JP_FULL_VAR,
@@ -997,14 +1000,26 @@ class TestFeaturePreservation:
 
         gpos = font["GPOS"].table
 
-        # Find kern feature indices referenced by DFLT script
-        dflt_kern_feat_indices = set()
-        for sr in gpos.ScriptList.ScriptRecord:
-            if sr.ScriptTag == "DFLT" and sr.Script.DefaultLangSys:
-                for fi in sr.Script.DefaultLangSys.FeatureIndex:
-                    if gpos.FeatureList.FeatureRecord[fi].FeatureTag == "kern":
-                        dflt_kern_feat_indices.add(fi)
+        def kern_feature_indices(script_tag):
+            indices = set()
+            for sr in gpos.ScriptList.ScriptRecord:
+                if sr.ScriptTag == script_tag and sr.Script.DefaultLangSys:
+                    for fi in sr.Script.DefaultLangSys.FeatureIndex:
+                        if gpos.FeatureList.FeatureRecord[fi].FeatureTag == "kern":
+                            indices.add(fi)
+            return indices
+
+        # Match Noto's source shape: scripts share one kern feature record.
+        dflt_kern_feat_indices = kern_feature_indices("DFLT")
         assert dflt_kern_feat_indices, "DFLT script should have kern features"
+        assert len(dflt_kern_feat_indices) == 1, (
+            "DFLT should expose a single kern feature so Adobe apps do not "
+            f"skip the base CJK kern path: {dflt_kern_feat_indices}"
+        )
+        for script_tag in ("hani", "kana", "latn"):
+            assert kern_feature_indices(script_tag) == dflt_kern_feat_indices, (
+                f"{script_tag} should share the same merged kern feature as DFLT"
+            )
 
         # Collect all kern lookup indices reachable from DFLT
         dflt_kern_lookups = set()
@@ -1028,6 +1043,10 @@ class TestFeaturePreservation:
                     idx = st.Coverage.glyphs.index("uni3059")
                     for pvr in st.PairSet[idx].PairValueRecord:
                         if pvr.SecondGlyph == "uni3002":
+                            assert lookup.LookupType == 2, (
+                                "CJK kern PairPos should stay direct LookupType 2 "
+                                "for Adobe compatibility"
+                            )
                             assert pvr.Value1.XAdvance == -100
                             found = True
         assert found, "す。kern pair (XAdvance=-100) should be reachable from DFLT"


### PR DESCRIPTION
Created with Codex GPT-5.5.

## Summary

- Fold JP/base and Latin GPOS `kern` feature records into one merged feature record, matching the Noto Sans JP source shape across `DFLT`, `hani`, `kana`, and `latn`.
- Preserve the JP/base PairPos lookup first in that merged `kern` feature, with Latin-first entries stripped so CJK pairs keep base values and Latin pairs fall through to Latin lookups without stacking.
- Add an Adobe compatibility save fallback that rewrites only when a non-Latin kern PairPos is emitted behind ExtensionPos (`LookupType 9`).
- Document the Adobe-compatible kern feature shape in both architecture docs.

## Root Cause

The merged font could expose separate JP and Latin `kern` feature records, or let `latn` resolve only to the Latin source kern path. Illustrator could then apply `palt` while ignoring CJK pair kerning such as `す。`. Large merged GPOS tables could also hide CJK PairPos data behind ExtensionPos, which Adobe apps appear not to apply for Japanese metrics kerning.

## Validation

- Verified manually in Adobe Illustrator that Japanese kerning now applies.
- `python3 -m pytest python/tests/test_glyph_data.py::TestLatinKernPreservation python/tests/test_glyph_data.py::TestFeaturePreservation python/tests/test_glyph_data.py::TestSharedGlyphCollateral -q`
- `python3 -m pytest python/tests/test_filter_subordinate_lookups.py -q`
- `python3 -m pytest python/tests/test_pipeline.py -q`
- `git diff --check`