### PR TITLE
Drop STAT and resync style bits for static outputs (#16)

### DIFF
--- a/docs/ARCHITECTURE.ja.md
+++ b/docs/ARCHITECTURE.ja.md
@@ -226,6 +226,32 @@ Latin script の LangSys を持たない場合（例: Latin サブが Greek 非�
 - OS/2, hhea のアセンダー/ディセンダーは両フォントのエンベロープ（出力 UPM 単位）
 - Latin のスケール/ベースラインはグローバルメトリクスに影響しない
 
+### 静的出力としての識別
+
+ofl-font-baker は常に static インスタンスを出力する。base / sub は
+マージ前にそれぞれの軸位置でインスタンス化され、ソースフォントが
+持っていたファミリー階層情報は出力に持ち込まない:
+
+- `STAT` は無条件で削除する。`fontTools.varLib.instancer` は STAT
+  をインスタンス化位置だけ残して prune するため、軸レコードが残骸と
+  して残ったり、軸上にない位置（例: `wght=465`）では部分的なテーブル
+  になる。さらに `output.weight/italic/width` で上書きされると、継承
+  された STAT が静的識別と矛盾する。Inter のような static TTF
+  ファミリーは STAT を持たずに出荷されることが多く、`name` / `OS/2`
+  を識別の唯一の真実とするためにも static 出力で STAT は不要 (Issue
+  #16)。
+- `OS/2.fsSelection` の REGULAR / BOLD / ITALIC、`head.macStyle` の
+  bold / italic ビットは `(weight, italic, width)` から再計算する。
+  `usWeightClass` / `usWidthClass` と italic フラグに矛盾しないように
+  揃える。REGULAR は本当の Regular 面（weight 400・width 5・非
+  italic）にだけ立てる。Light / Medium / SemiBold など RIBBI に入ら
+  ないメンバーは REGULAR をクリアしないと、フォントマッチャがそれを
+  ファミリーの Regular だと誤認する。
+
+継承モードでは、`weight` / `italic` / `width` のいずれかが上書き
+されたときだけビットを再計算する。何も指定しないピュアパススルー時
+は継承元のビットをそのまま残す。
+
 ### OFL メタデータ
 
 デフォルト（`output.metadataMode = "merge"` または未指定）では、出力を新しい
@@ -351,6 +377,7 @@ python3 -m pytest python/tests/ -k LargeCID -v         # 65535 グリフ CID テ
 |---|---|---|
 | Filter subordinate lookups | 7 | helper-level: ScriptList & cross-lookup remap、Format 1 rule rename、Type 5 F3 collector |
 | Variable instantiation | 4 | wght bake、JP weight、fvar 除去、デフォルト axes |
+| Static style identity | 15 | merge / inheritBase / inheritSub での STAT 削除、fsSelection REGULAR/BOLD/ITALIC + macStyle bold/italic |
 | Baseline offset | 4 | simple シフト、Latin & JP composite 二重シフト防止、JP 非影響 |
 | Scale | 2 | グリフサイズ、advance width |
 | UPM normalization | 3 | 2048→1000 変換、OS/2 metrics |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -230,6 +230,31 @@ sub doesn't ship Greek), the JP-side `ccmp` for that script stays put
 - OS/2 and hhea ascender/descender are the envelope of both fonts in output UPM
 - Latin scale/baseline do not affect global metrics
 
+### Static output identity
+
+ofl-font-baker only emits static instances. Both the base and sub
+fonts are instantiated at their selected axis location before merging,
+and any source-font style hierarchy is dropped:
+
+- `STAT` is removed unconditionally. `fontTools.varLib.instancer`
+  prunes STAT to the instantiated location and leaves stale axis
+  records (or a partial table for off-axis instances such as
+  `wght=465`); any subsequent `output.weight/italic/width` override
+  would make the inherited STAT contradict the static identity. Static
+  TTF families like Inter ship without STAT, so dropping it lets
+  `name` / `OS/2` be the single source of truth (Issue #16).
+- `OS/2.fsSelection` REGULAR / BOLD / ITALIC and `head.macStyle`
+  bold / italic are recomputed from `(weight, italic, width)` so the
+  bits agree with `usWeightClass` / `usWidthClass` and the italic
+  flag. REGULAR is reserved for the actual Regular face — weight 400,
+  width 5, non-italic. Light / Medium / SemiBold and other non-RIBBI
+  members must clear REGULAR or font-matchers pick them as the
+  family's regular style.
+
+In inherit modes, the bits are recomputed only when at least one
+style component (`weight` / `italic` / `width`) is overridden; pure
+pass-through keeps the source bits untouched.
+
 ### OFL Metadata
 
 The default mode (`output.metadataMode = "merge"` or absent) treats the
@@ -356,6 +381,7 @@ Test code is split across four files under `python/tests/`:
 |---|---|---|
 | Filter subordinate lookups | 7 | Helper-level: ScriptList & cross-lookup remap, Format 1 rule rename, Type 5 F3 collector |
 | Variable instantiation | 4 | wght bake, JP weight, fvar removal, default axes |
+| Static style identity | 15 | STAT removal across modes, fsSelection REGULAR/BOLD/ITALIC + macStyle bold/italic for merge / inheritBase / inheritSub |
 | Baseline offset | 4 | Simple shift, Latin & JP composite double-shift prevention, JP unaffected |
 | Scale | 2 | Glyph size, advance width |
 | UPM normalization | 3 | 2048→1000 conversion, OS/2 metrics |

--- a/python/merge_fonts.py
+++ b/python/merge_fonts.py
@@ -2390,11 +2390,54 @@ def _set_ofl_metadata(lat_font, jp_font, merged, config: dict):
 # Identity passes (merge-mode default vs. inherit-mode pass-through)
 # ---------------------------------------------------------------------------
 
-# OS/2 fsSelection bit 0 = ITALIC, bit 6 = REGULAR.
+# OS/2 fsSelection bits.
 _FS_SELECTION_ITALIC = 0x0001
+_FS_SELECTION_BOLD = 0x0020
 _FS_SELECTION_REGULAR = 0x0040
-# head.macStyle bit 1 = italic.
+# head.macStyle bit 0 = bold, bit 1 = italic.
+_MAC_STYLE_BOLD = 0x0001
 _MAC_STYLE_ITALIC = 0x0002
+
+
+def _apply_style_bits(os2, head, weight: int, italic: bool, width: int = 5) -> None:
+    """Sync OS/2.fsSelection and head.macStyle to the static style identity.
+
+    REGULAR / BOLD / ITALIC in fsSelection and the bold / italic bits in
+    head.macStyle must agree with ``usWeightClass`` / ``usWidthClass``
+    and the italic flag, or Windows and Adobe pick the wrong style when
+    matching the family. Re-syncing here also fixes inherited
+    inconsistencies (e.g. a base font that carried ``fsSelection=REGULAR``
+    while the derivative is Bold).
+
+    REGULAR (bit 6) is only set on the actual Regular face — weight 400,
+    width 5, non-italic. Light / Medium / SemiBold and other non-RIBBI
+    members of a family must clear REGULAR so font-matchers don't pick
+    them as the family's regular style.
+    """
+    is_bold = weight >= 700
+    is_regular = (weight == 400 and width == 5 and not italic)
+    if os2 is not None:
+        if italic:
+            os2.fsSelection |= _FS_SELECTION_ITALIC
+        else:
+            os2.fsSelection &= ~_FS_SELECTION_ITALIC
+        if is_bold:
+            os2.fsSelection |= _FS_SELECTION_BOLD
+        else:
+            os2.fsSelection &= ~_FS_SELECTION_BOLD
+        if is_regular:
+            os2.fsSelection |= _FS_SELECTION_REGULAR
+        else:
+            os2.fsSelection &= ~_FS_SELECTION_REGULAR
+    if head is not None:
+        if italic:
+            head.macStyle |= _MAC_STYLE_ITALIC
+        else:
+            head.macStyle &= ~_MAC_STYLE_ITALIC
+        if is_bold:
+            head.macStyle |= _MAC_STYLE_BOLD
+        else:
+            head.macStyle &= ~_MAC_STYLE_BOLD
 
 
 def _apply_derivative_metadata(lat_font, jp_font, merged, config: dict):
@@ -2460,14 +2503,10 @@ def _apply_derivative_metadata(lat_font, jp_font, merged, config: dict):
         # font's tag would misattribute the derivative.
         os2.achVendID = "    "
 
-    # Set italic flags + refresh timestamps so the derivative reports its
-    # own creation/modification time rather than inheriting the base font's.
+    # Refresh timestamps so the derivative reports its own creation/
+    # modification time rather than inheriting the base font's.
     head = merged.get("head")
     if head:
-        if output_italic:
-            head.macStyle |= _MAC_STYLE_ITALIC
-        else:
-            head.macStyle &= ~_MAC_STYLE_ITALIC
         now = timestampNow()
         head.created = now
         head.modified = now
@@ -2483,12 +2522,13 @@ def _apply_derivative_metadata(lat_font, jp_font, merged, config: dict):
         # (1.0 / 2.5). Anything that doesn't start with a number falls
         # back to the 1.000 default.
         head.fontRevision = _parse_font_revision(output.get("version"))
-    if os2:
-        if output_italic:
-            os2.fsSelection |= _FS_SELECTION_ITALIC
-            os2.fsSelection &= ~_FS_SELECTION_REGULAR
-        else:
-            os2.fsSelection &= ~_FS_SELECTION_ITALIC
+
+    # Sync REGULAR / BOLD / ITALIC bits in OS/2.fsSelection and the
+    # bold / italic bits in head.macStyle to the output style. Inherited
+    # bits would otherwise contradict the new identity — base fonts that
+    # carried fsSelection=REGULAR keep advertising "Regular" even when
+    # the derivative is Bold or any other non-Regular weight.
+    _apply_style_bits(os2, head, output_weight, output_italic, output_width)
 
     # Update name table style entries
     for record in name_table.names:
@@ -2738,19 +2778,15 @@ def _apply_inherited_metadata(lat_font, jp_font, merged, config: dict, mode: str
             os2.usWidthClass = new_width
             overrides.append(f"width={new_width}")
         if italic_specified:
-            if new_italic:
-                os2.fsSelection |= _FS_SELECTION_ITALIC
-                os2.fsSelection &= ~_FS_SELECTION_REGULAR
-            else:
-                os2.fsSelection &= ~_FS_SELECTION_ITALIC
             overrides.append(f"italic={new_italic}")
 
-    # head.macStyle italic bit + fontRevision -----------------------------
-    if head and italic_specified:
-        if new_italic:
-            head.macStyle |= _MAC_STYLE_ITALIC
-        else:
-            head.macStyle &= ~_MAC_STYLE_ITALIC
+    # Style bits ----------------------------------------------------------
+    # Recompute fsSelection REGULAR/BOLD/ITALIC and head.macStyle bold/
+    # italic when any style component is overridden so the inherited bits
+    # don't contradict the new style. Pure pass-through (no style
+    # override) keeps the source bits untouched.
+    if style_changed:
+        _apply_style_bits(os2, head, new_weight, new_italic, new_width)
 
     # nameID 5 (version) + head.fontRevision ------------------------------
     version_specified = "version" in output
@@ -2997,6 +3033,19 @@ def reconcile_tables(lat_font: TTFont, jp_font: TTFont, merged: TTFont, config: 
     # --- Remove DSIG (will be invalid) ---
     if "DSIG" in merged:
         del merged["DSIG"]
+
+    # --- Remove STAT ---
+    # STAT (Style Attributes) places the font within a family's style
+    # hierarchy. fontTools.varLib.instancer prunes it to the instantiated
+    # location, leaving stale axis records — or a partial table for
+    # off-axis instances (e.g. wght=465) — and any output.weight /
+    # italic / width override would make the inherited STAT contradict
+    # the static identity. ofl-font-baker only emits static instances,
+    # so the safer default (matching many static TTF families like
+    # Inter) is to drop STAT and let name / OS/2 be the source of truth.
+    # See issue #16.
+    if "STAT" in merged:
+        del merged["STAT"]
 
     # --- post table: use format 2.0 to preserve glyph names ---
     # Format 3.0 discards all glyph names, causing GSUB/GPOS lookups

--- a/python/tests/test_metadata.py
+++ b/python/tests/test_metadata.py
@@ -47,6 +47,186 @@ class TestOutputWeight:
 
 
 # ---------------------------------------------------------------------------
+# Static-output style identity: STAT removal + fsSelection / macStyle
+# (Issue #16)
+# ---------------------------------------------------------------------------
+
+_FS_ITALIC = 0x0001
+_FS_BOLD = 0x0020
+_FS_REGULAR = 0x0040
+_MAC_BOLD = 0x0001
+_MAC_ITALIC = 0x0002
+
+
+def _merge_with_italic(output_weight=400, output_italic=False,
+                       metadata_mode=None):
+    """Run a merge that lets the test choose italic + metadataMode."""
+    out = tempfile.mktemp(suffix=".ttf")
+    output = {
+        "familyName": "StyleTest",
+        "weight": output_weight,
+        "italic": output_italic,
+    }
+    if metadata_mode is not None:
+        output["metadataMode"] = metadata_mode
+    config = {
+        "subFont": {
+            "path": EN_VAR, "scale": 1.0, "baselineOffset": 0,
+            "axes": [
+                {"tag": "opsz", "currentValue": 14},
+                {"tag": "wght", "currentValue": 400},
+            ],
+        },
+        "baseFont": {
+            "path": JP_VAR, "scale": 1.0, "baselineOffset": 0,
+            "axes": [{"tag": "wght", "currentValue": 400}],
+        },
+        "output": output,
+        "export": {"path": {"font": out}},
+    }
+    mf.merge_fonts(config)
+    font = TTFont(out)
+    for f in (out, out.replace(".ttf", ".woff2")):
+        if os.path.exists(f):
+            os.remove(f)
+    return font
+
+
+class TestStripStat:
+    """STAT must not survive into static outputs.
+
+    fontTools.varLib.instancer prunes STAT to the instantiated location,
+    leaving stale axis records (or a partial table for off-axis instances).
+    Once output.weight/italic/width overrides change the static identity,
+    inherited STAT contradicts the name table / OS/2.
+    """
+
+    def test_merge_mode_drops_stat(self):
+        """Merge mode removes STAT regardless of source."""
+        # Sanity: source has STAT (so the test is meaningful).
+        assert "STAT" in TTFont(JP_VAR)
+        m = _merge(output_weight=700)
+        assert "STAT" not in m
+
+    def test_inherit_base_drops_stat(self):
+        """inheritBase also drops STAT — static outputs don't need it."""
+        m = _merge_inherit("inheritBase")
+        assert "STAT" not in m
+
+    def test_inherit_base_with_weight_drops_stat(self):
+        """inheritBase + weight override (the issue #16 scenario)."""
+        m = _merge_inherit("inheritBase", {"weight": 700})
+        assert "STAT" not in m
+
+    def test_inherit_sub_drops_stat(self):
+        """inheritSub also drops STAT."""
+        m = _merge_inherit("inheritSub")
+        assert "STAT" not in m
+
+
+class TestStyleBitsMergeMode:
+    """OS/2.fsSelection REGULAR/BOLD/ITALIC and head.macStyle bold/italic
+    must agree with output.weight + output.italic. The base font's bits
+    must not leak into the derivative."""
+
+    def test_regular_sets_regular_clears_bold_italic(self):
+        m = _merge(output_weight=400)
+        fs = m["OS/2"].fsSelection
+        ms = m["head"].macStyle
+        assert fs & _FS_REGULAR
+        assert not (fs & _FS_BOLD)
+        assert not (fs & _FS_ITALIC)
+        assert not (ms & _MAC_BOLD)
+        assert not (ms & _MAC_ITALIC)
+
+    def test_bold_sets_bold_clears_regular(self):
+        """Issue #16: weight=700 must clear inherited REGULAR bit."""
+        m = _merge(output_weight=700)
+        fs = m["OS/2"].fsSelection
+        ms = m["head"].macStyle
+        assert fs & _FS_BOLD, f"BOLD bit missing in fsSelection={fs:#x}"
+        assert not (fs & _FS_REGULAR), \
+            f"REGULAR bit still set in fsSelection={fs:#x}"
+        assert ms & _MAC_BOLD, f"macStyle bold bit missing in {ms:#x}"
+
+    def test_extra_bold_also_sets_bold(self):
+        """weight >= 700 sets the bold bits."""
+        m = _merge(output_weight=800)
+        fs = m["OS/2"].fsSelection
+        assert fs & _FS_BOLD
+        assert not (fs & _FS_REGULAR)
+
+    @pytest.mark.parametrize("weight,name", [
+        (300, "Light"),
+        (500, "Medium"),
+        (600, "SemiBold"),
+    ])
+    def test_non_regular_weights_clear_regular_bit(self, weight, name):
+        """Light / Medium / SemiBold must clear REGULAR — only the actual
+        Regular face (weight=400, normal width, non-italic) advertises it.
+        Otherwise font matchers would pick e.g. SemiBold as the family's
+        Regular style."""
+        m = _merge(output_weight=weight)
+        # Sanity: confirm we really did get the non-Regular style.
+        assert m["name"].getDebugName(2) == name
+        fs = m["OS/2"].fsSelection
+        assert not (fs & _FS_REGULAR), \
+            f"REGULAR must be clear for {name}, got fsSelection={fs:#x}"
+        assert not (fs & _FS_BOLD)
+        assert not (fs & _FS_ITALIC)
+
+    def test_italic_sets_italic_clears_regular(self):
+        m = _merge_with_italic(output_weight=400, output_italic=True)
+        fs = m["OS/2"].fsSelection
+        ms = m["head"].macStyle
+        assert fs & _FS_ITALIC
+        assert not (fs & _FS_REGULAR)
+        assert not (fs & _FS_BOLD)
+        assert ms & _MAC_ITALIC
+        assert not (ms & _MAC_BOLD)
+
+    def test_bold_italic_sets_both(self):
+        m = _merge_with_italic(output_weight=700, output_italic=True)
+        fs = m["OS/2"].fsSelection
+        ms = m["head"].macStyle
+        assert fs & _FS_BOLD
+        assert fs & _FS_ITALIC
+        assert not (fs & _FS_REGULAR)
+        assert ms & _MAC_BOLD
+        assert ms & _MAC_ITALIC
+
+
+class TestStyleBitsInheritMode:
+    """Inherit mode must re-sync style bits when any style component is
+    overridden, but leave them alone in pure pass-through."""
+
+    def test_pure_passthrough_keeps_bits(self):
+        """No style override → fsSelection is preserved verbatim."""
+        base = TTFont(JP_VAR)
+        base_fs = base["OS/2"].fsSelection
+        m = _merge_inherit("inheritBase")
+        assert m["OS/2"].fsSelection == base_fs
+
+    def test_weight_override_recomputes_bits(self):
+        """Issue #16 root case: inheritBase + weight=700 must clear
+        the inherited REGULAR bit and set BOLD even when italic isn't
+        explicitly specified."""
+        m = _merge_inherit("inheritBase", {"weight": 700})
+        fs = m["OS/2"].fsSelection
+        ms = m["head"].macStyle
+        assert fs & _FS_BOLD, f"BOLD missing in fsSelection={fs:#x}"
+        assert not (fs & _FS_REGULAR), \
+            f"REGULAR still set in fsSelection={fs:#x}"
+        assert ms & _MAC_BOLD
+
+    def test_italic_override_clears_regular(self):
+        m = _merge_inherit("inheritBase", {"italic": True})
+        fs = m["OS/2"].fsSelection
+        assert fs & _FS_ITALIC
+        assert not (fs & _FS_REGULAR)
+
+
+# ---------------------------------------------------------------------------
 # PostScript name sanitization and validation
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Drop `STAT` unconditionally in `reconcile_tables`. `fontTools.varLib.instancer` prunes STAT to the instantiated location and leaves stale axis records (or a partial table for off-axis instances such as `wght=465`); subsequent `output.weight/italic/width` overrides make the inherited STAT contradict the static identity. ofl-font-baker only emits static instances, so STAT removal lets `name` / `OS/2` be the single source of truth — matching how Inter and other static TTF families ship.
- Resync `OS/2.fsSelection` REGULAR / BOLD / ITALIC and `head.macStyle` bold / italic from `(weight, italic, width)` via the new `_apply_style_bits()` helper. Inherited bits would otherwise contradict the new identity — base fonts that carried `fsSelection=REGULAR` keep advertising "Regular" even when the derivative is Bold (the originally reported case) **or** any non-RIBBI weight.
- REGULAR is reserved for the actual Regular face — weight 400, width 5, non-italic. Light / Medium / SemiBold and other non-RIBBI members no longer advertise themselves as the family's regular style; otherwise font-matchers would pick e.g. SemiBold when the user requests "Regular."
- In inherit modes, the bit resync only fires when at least one of `weight` / `italic` / `width` is overridden; pure pass-through keeps the source bits untouched.

Fixes #16.

## Test plan

- [x] `python3 -m pytest python/tests/test_metadata.py` — 122 passed (15 new tests for STAT removal + style bit consistency).
- [x] `npm test` — 334 passed, 1 skipped (full pytest suite).
- [x] `npm run build` clean.
- New tests:
  - `TestStripStat` (4): merge / inheritBase / inheritBase + weight=700 / inheritSub all drop STAT.
  - `TestStyleBitsMergeMode` (8): Regular sets REGULAR; weight=700 / 800 set BOLD and clear REGULAR; italic / bold-italic combos; parametrized 300 Light / 500 Medium / 600 SemiBold all clear REGULAR.
  - `TestStyleBitsInheritMode` (3): pure pass-through preserves source bits; weight override (the issue #16 root case) re-syncs; italic override clears REGULAR.

## Docs

`docs/ARCHITECTURE.md` and `docs/ARCHITECTURE.ja.md` get a new "Static output identity" / 「静的出力としての識別」 subsection plus a row in the test count table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)