### PR TITLE
[codex] Normalize TrueType hinting output

### DIFF
--- a/app/shared/types.ts
+++ b/app/shared/types.ts
@@ -58,6 +58,8 @@ export interface MergeOutput {
   /** Extra trademark text appended after source trademarks (nameID 7). */
   trademark: string;
   upm: number;
+  /** TrueType output hinting policy. Defaults to Python engine's safe strip mode. */
+  hinting?: 'strip' | 'unhinted' | 'none' | 'ttfautohint' | 'autohint';
 }
 
 export interface MergePackage {

--- a/docs/ARCHITECTURE.ja.md
+++ b/docs/ARCHITECTURE.ja.md
@@ -122,6 +122,19 @@ TT→CFF グリフコピー時は `ReverseContourPen` を必ず挟む。TT は�
 
 CFF のヒント保持: ヒント命令と Private dict（ブルーゾーン・ステム幅）はアウトラインと同じアフィン変換で再計算するので、マージ後もヒントがグリフ位置と整合する。
 
+### TrueType ヒンティング方針
+
+TrueType の bytecode hinting はフォント全体で成立する仕組みで、各グリフのプログラムは `fpgm` / `prep` / `cvt ` / `maxp` カウンタが同一ソース由来であることを前提にしている。サブフォントのグリフ bytecode をベースフォントのヒント環境で実行すると、関数番号・ストレージスロット・CVT エントリが衝突し、結果として「どのソースの整合も取れていない」状態になる。
+
+`normalize_truetype_hinting` は maxp 再計算の直後・保存直前に走り、以下を行う。
+
+- 全グリフの `program.bytecode` をクリア
+- `fpgm` / `prep` / `cvt ` テーブルを削除
+- `maxp` v1 のヒント関連フィールド（`maxTwilightPoints` / `maxStorage` / `maxFunctionDefs` / `maxInstructionDefs` / `maxStackElements` / `maxSizeOfInstructions`）を 0 に正規化。`maxZones` は OpenType 仕様上 unhinted でも 1 が必要なので 1 に固定
+- `gasp` はそのまま残す（スムージング戦略のテーブルで bytecode 実行とは独立）
+
+オプションの後段処理として `output.hinting = "ttfautohint"`（エイリアス `"autohint"`）を指定すると、上記の strip 済み TTF を一度書き出した後で外部 `ttfautohint` バイナリをそのファイルに対してインプレースで実行する。ツールが見つからない場合は黙って fallback せずエラーを上げる。デフォルトの `"strip"`（`"unhinted"` / `"none"` も同義）は unhinted のまま出力し、小サイズはプラットフォームのオートヒンタに委ねる。CFF 出力は別系統のヒント保持パスを使う。
+
 ### 統合 UPM / スケール / ベースライン変換
 
 `outputUpm`（UI で編集可能、デフォルト 1000）は JP 側のマージに対する単一
@@ -391,7 +404,7 @@ python3 -m pytest python/tests/ -k LargeCID -v         # 65535 グリフ CID テ
 | Glyph names | 2 | post format 2.0、代替グリフ名 |
 | Composite integrity | 2 | 参照完全性、hmtx 完全性 |
 | Metrics preservation | 10 | UPM、OS/2、hhea、scale/baseline 非影響 |
-| TT hinting preservation | 7 | prep / gasp / maxp、instructions クリア (scale 時) |
+| TT hinting normalization | 10 | fpgm / prep / cvt 削除、gasp 保持、glyph program クリア、maxp ヒントカウンタ 0、ヒント付きサブフォント regression、ttfautohint ポリシー配線 |
 | Maxp recalc | 1 | merge 後の maxp サブフィールド再計算 |
 | CFF hint preservation | 8 | hstem / vstem / BlueValues 保持 (CFF→CFF)、TopDict と nameID の整合 |
 | CFF coincidence snap | 3 | スケール経由でも一致頂点を保持 |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -122,6 +122,19 @@ TT→CFF glyph copy (used for Latin sources that don't match the base) always in
 
 CFF hint preservation: hint operators and `Private` dict blue zones / stem widths are scaled by the same affine (scale, baseline) used on the outlines, so hints continue to align with the transformed glyph after merge.
 
+### TrueType Hinting Policy
+
+TrueType bytecode hinting is font-wide: per-glyph programs depend on `fpgm`, `prep`, `cvt `, and matching `maxp` workspace counters from the same source. Mixing the sub font's glyph bytecode with the base font's hint program is unsafe — function indices, storage slots, and CVT entries collide silently and the rendered output is no longer hinted against any consistent state.
+
+`normalize_truetype_hinting` runs after the maxp recompute, just before save:
+
+- Every glyph's `program.bytecode` is cleared.
+- `fpgm`, `prep`, and `cvt ` are deleted.
+- `maxp` v1 hint counters (`maxTwilightPoints`, `maxStorage`, `maxFunctionDefs`, `maxInstructionDefs`, `maxStackElements`, `maxSizeOfInstructions`) are zeroed; `maxZones` is forced to `1` because OpenType requires it even for unhinted output.
+- `gasp` is left in place — it controls smoothing strategy, not bytecode execution.
+
+Optional post-process: when `output.hinting = "ttfautohint"` (alias `"autohint"`), the merge writes the stripped TTF first, then runs the external `ttfautohint` binary in place. If the tool is missing, the merge raises rather than silently falling back. The default `"strip"` (alias `"unhinted"` / `"none"`) ships unhinted and lets the platform autohinter handle small sizes. CFF output keeps its separate CFF hint-preserving path.
+
 ### Unified UPM / Scale / Baseline Transform
 
 `outputUpm` (user-editable, default 1000 in the UI) drives a single affine
@@ -395,7 +408,7 @@ Test code is split across four files under `python/tests/`:
 | Glyph names | 2 | post format 2.0, alternate glyph names |
 | Composite integrity | 2 | Reference completeness, hmtx completeness |
 | Metrics preservation | 10 | UPM, OS/2, hhea, scale/baseline unaffected |
-| TT hinting preservation | 7 | prep / gasp / maxp, instructions cleared on scale |
+| TT hinting normalization | 10 | fpgm / prep / cvt dropped, gasp kept, glyph programs cleared, maxp hint counters zeroed, hinted-sub-font regression, ttfautohint policy plumbing |
 | Maxp recalc | 1 | maxp sub-fields refreshed after merge |
 | CFF hint preservation | 8 | hstem / vstem / BlueValues survive CFF→CFF, TopDict mirrors nameIDs |
 | CFF coincidence snap | 3 | Coincident vertices preserved through scale |

--- a/python/README.ja.md
+++ b/python/README.ja.md
@@ -114,6 +114,7 @@ cat config.json | python3 merge_fonts.py
 | `trademark`       | `""`         | ソースの商標に追加される商標文字列。                                                                                                                                            |
 | `metricsSource`   | `"base"`     | 垂直メトリクス（OS/2, hhea）の参照元。`"base"` はベースフォントのメトリクスを維持し、サブフォントの方が大きい場合のみ拡張する。`"sub"` はサブフォントのメトリクスで上書きする。 |
 | `metadataMode`    | `"merge"`    | 識別レコードのポリシー。`"merge"`（`null` または未指定も同義）は name / OS/2 / head の識別レコードを派生著作物として書き直す（現行のデフォルト）。`"inheritBase"` は base フォントの識別をそのまま流用、`"inheritSub"` は sub フォントの識別を流用する（`subFont` がなければエラー）。`output.*` で明示的に指定したフィールドだけが継承元を上書きし、OFL nameID 13/14・designer・vendor ID・`head.created/modified` などは触らない。中間生成物や、新しい派生として再宣言したくないマージ（例：`Noto Hentaigana` のグリフを `Noto Sans JP` に取り込みたい場合）に有用。 |
+| `hinting`         | `"strip"`    | TrueType 出力のヒンティング方針。`"strip"`（`"unhinted"` / `"none"` も同義）は TT bytecode、`fpgm`、`prep`、`cvt ` を削除し、unhinted outline として妥当な `maxp` に正規化する。`"ttfautohint"`（`"autohint"` も同義）は最終 TTF を一度 strip 状態で書き出した後、外部 `ttfautohint` バイナリを実行する。CFF 出力は別系統の CFF hint 保持処理を使う。 |
 
 ### `export.path`
 

--- a/python/README.md
+++ b/python/README.md
@@ -114,6 +114,7 @@ Progress is emitted as JSON lines on stderr.
 | `trademark`       | `""`        | Additional trademark string appended to source trademarks.                                                                                                                            |
 | `metricsSource`   | `"base"`    | Which font's vertical metrics (OS/2, hhea) to use. `"base"` keeps the base font metrics and expands only when the sub font is larger. `"sub"` overwrites with the sub font's metrics. |
 | `metadataMode`    | `"merge"`   | Identity policy. `"merge"` (or `null` / unset) rewrites name / OS/2 / head identity records as a fresh derivative work — current default. `"inheritBase"` passes the base font's identity through untouched; `"inheritSub"` does the same with the sub font (errors if `subFont` is absent). Only the `output.*` fields you explicitly set act as overrides on top of the inherited identity, and OFL nameID 13/14, designer, vendor ID, and `head.created/modified` are left alone. Useful for intermediate artifacts or merges that should not self-identify as a new derivative (e.g. adding `Noto Hentaigana` glyphs into `Noto Sans JP`). |
+| `hinting`         | `"strip"`   | TrueType output hinting policy. `"strip"` (also `"unhinted"` / `"none"`) removes TT bytecode, `fpgm`, `prep`, and `cvt `, while keeping `maxp` valid for unhinted outlines. `"ttfautohint"` (also `"autohint"`) first writes the final stripped TTF, then runs an external `ttfautohint` binary over the finished font. CFF output keeps its separate CFF hint-preserving path. |
 
 ### `export.path`
 

--- a/python/merge_fonts.py
+++ b/python/merge_fonts.py
@@ -28,6 +28,7 @@ import os
 import re
 import shutil
 import struct
+import subprocess
 import sys
 
 from fontTools.misc.timeTools import timestampNow
@@ -440,7 +441,8 @@ def build_export_config(config: dict, path_map: dict = None) -> dict:
     output = config.get("output") or {}
     for field in ("familyName", "postScriptName", "version", "weight", "italic",
                   "width", "manufacturer", "manufacturerURL",
-                  "copyright", "trademark", "upm", "metadataMode"):
+                  "copyright", "trademark", "upm", "metadataMode",
+                  "hinting"):
         val = output.get(field)
         if val is not None:
             result.setdefault("output", {})[field] = val
@@ -1177,6 +1179,123 @@ def transform_tt_glyph_inplace(font: TTFont, glyph_name: str,
     if glyph_name in hmtx.metrics:
         aw, lsb = hmtx.metrics[glyph_name]
         hmtx.metrics[glyph_name] = (int(round(aw * scale)), int(round(lsb * scale)))
+
+
+# ---------------------------------------------------------------------------
+# TrueType hinting normalization
+# ---------------------------------------------------------------------------
+
+# maxp v1 hint-related fields. Cleared together with the bytecode tables so
+# the merged font's "this is unhinted" status is consistent across maxp,
+# glyf, and the font-wide hint programs.
+_MAXP_HINT_FIELDS_ZERO = (
+    "maxTwilightPoints",
+    "maxStorage",
+    "maxFunctionDefs",
+    "maxInstructionDefs",
+    "maxStackElements",
+    "maxSizeOfInstructions",
+)
+
+
+def normalize_truetype_hinting(font: TTFont) -> None:
+    """Drop all TrueType bytecode hinting from a merged TTF.
+
+    Glyph bytecode from one source cannot reliably run against the font-wide
+    ``fpgm`` / ``prep`` / ``cvt `` from a different source: function indices,
+    storage slots, and CVT entries are all source-specific. The merge engine
+    happily mixes Latin glyphs with the base font's hint program, so we
+    publish unhinted output and let the platform's autohinter handle small
+    sizes. ``gasp`` is left in place — it controls smoothing strategy, not
+    bytecode execution.
+
+    Mirrors the policy described in Issue #17: per-glyph programs are
+    cleared, ``fpgm`` / ``prep`` / ``cvt `` are removed, and the maxp v1
+    hint counters are reset to zero so renderers don't reserve workspace
+    for instructions that aren't there.
+    """
+    if "glyf" not in font:
+        return  # CFF output uses a separate hint-preserving path.
+
+    from array import array
+
+    glyf = font["glyf"]
+    for gname in glyf.glyphOrder:
+        try:
+            g = glyf[gname]
+        except KeyError:
+            continue
+        program = getattr(g, "program", None)
+        if program is not None and getattr(program, "bytecode", None):
+            program.bytecode = array("B")
+
+    for tag in ("fpgm", "prep", "cvt "):
+        if tag in font:
+            del font[tag]
+
+    maxp = font.get("maxp")
+    if maxp is not None:
+        if hasattr(maxp, "maxZones"):
+            # OpenType maxp v1 requires maxZones to be 1 when instructions
+            # do not use the twilight zone. Zero is not a conformant value,
+            # even for unhinted TrueType outlines.
+            maxp.maxZones = 1
+        for attr in _MAXP_HINT_FIELDS_ZERO:
+            if hasattr(maxp, attr):
+                setattr(maxp, attr, 0)
+
+
+def _resolve_hinting_policy(config: dict) -> str:
+    """Resolve output hinting policy for TrueType output.
+
+    The default is ``strip`` because preserving mixed-source TT bytecode is
+    unsafe. ``ttfautohint`` is an opt-in post-process for environments that
+    provide the external tool.
+    """
+    output = config.get("output") or {}
+    raw = (output.get("hinting") or "strip").strip().lower()
+    aliases = {
+        "none": "strip",
+        "unhinted": "strip",
+        "strip": "strip",
+        "ttfautohint": "ttfautohint",
+        "autohint": "ttfautohint",
+    }
+    if raw not in aliases:
+        raise ValueError(
+            "output.hinting must be one of: strip, unhinted, none, "
+            "ttfautohint, autohint"
+        )
+    return aliases[raw]
+
+
+def _apply_ttfautohint(output_path: str, tool_path: str = None) -> None:
+    """Run ttfautohint over the final saved TTF file in-place."""
+    exe = tool_path or shutil.which("ttfautohint")
+    if not exe:
+        raise RuntimeError(
+            "output.hinting=ttfautohint requested, but ttfautohint was not "
+            "found on PATH"
+        )
+
+    tmp_path = f"{output_path}.ttfautohint.tmp"
+    try:
+        subprocess.run(
+            [exe, output_path, tmp_path],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        os.replace(tmp_path, output_path)
+    except subprocess.CalledProcessError as e:
+        stderr = e.stderr.decode("utf-8", errors="replace").strip()
+        raise RuntimeError(
+            f"ttfautohint failed for {os.path.basename(output_path)}"
+            + (f": {stderr}" if stderr else "")
+        ) from e
+    finally:
+        if os.path.exists(tmp_path):
+            os.remove(tmp_path)
 
 
 # ---------------------------------------------------------------------------
@@ -3171,6 +3290,7 @@ def merge_fonts(config: dict) -> str:
     output = config.get("output") or {}
     lat_cfg = config.get("subFont")
     jp_cfg = config["baseFont"]
+    hinting_policy = _resolve_hinting_policy(config)
 
     if "woff2" in paths and "font" not in paths:
         raise ValueError("export.path.woff2 requires export.path.font")
@@ -3868,6 +3988,13 @@ def merge_fonts(config: dict) -> str:
         ):
             if hasattr(_maxp, attr):
                 setattr(_maxp, attr, max(getattr(_maxp, attr, 0), value))
+
+    # Normalize TT hinting for merged TTF output (Issue #17). Glyph-level
+    # bytecode from the sub font cannot reliably execute against the base
+    # font's fpgm/prep/cvt, and partial preservation made the output look
+    # bytecode-hinted to renderers without actually moving any points.
+    if "glyf" in merged:
+        normalize_truetype_hinting(merged)
     # Ensure parent directory exists for all path-mode outputs
     for p in (output_path, paths.get("woff2"), paths.get("ofl"),
               paths.get("settings"), paths.get("config")):
@@ -3886,12 +4013,21 @@ def merge_fonts(config: dict) -> str:
         }
     _save_with_adobe_kern_compat(merged, output_path, output_lat_glyph_names)
 
+    font_for_woff2 = merged
+    if "glyf" in merged and hinting_policy == "ttfautohint":
+        progress("writing", 9, f"4/{S} \u00b7 Applying TrueType autohint...")
+        _apply_ttfautohint(output_path)
+        if paths.get("woff2"):
+            font_for_woff2 = TTFont(output_path)
+
     # Step 14: Write WOFF2
     woff2_out = paths.get("woff2")
     if woff2_out:
         progress("writing", 10, f"5/{S} \u00b7 Exporting .woff2...")
-        merged.flavor = "woff2"
-        merged.save(woff2_out)
+        font_for_woff2.flavor = "woff2"
+        font_for_woff2.save(woff2_out)
+        if font_for_woff2 is not merged:
+            font_for_woff2.close()
 
     # Path-mode artifact writing
     ofl_out = paths.get("ofl")

--- a/python/tests/test_glyph_data.py
+++ b/python/tests/test_glyph_data.py
@@ -1278,14 +1278,21 @@ class TestOutputUpm:
 
 
 # ---------------------------------------------------------------------------
-# TrueType hinting preservation
+# TrueType hinting normalization (Issue #17)
 # ---------------------------------------------------------------------------
 
-class TestHintingPreservation:
-    """Verify that base font TrueType hinting tables survive merge.
+class TestHintingNormalization:
+    """Merged TTF output is published unhinted.
 
-    The merged font is cloned from the base (JP) font, so fpgm / prep /
-    cvt / gasp tables should be preserved as-is.
+    Mixing glyph bytecode from one source with the font-wide ``fpgm`` /
+    ``prep`` / ``cvt `` of another source is unsafe: function indices,
+    storage slots, and CVT entries are source-specific. The previous
+    behavior left hint state from the base font in the output while the
+    sub font's glyph programs survived alongside it, so the output looked
+    bytecode-hinted to renderers without actually moving any points. The
+    merge engine now strips bytecode hinting entirely and lets the
+    platform autohinter handle small sizes; ``gasp`` is left in place
+    because it controls smoothing strategy, not bytecode execution.
     """
 
     @pytest.fixture(autouse=True)
@@ -1295,55 +1302,69 @@ class TestHintingPreservation:
         jp = TTFont(JP_VAR)
         self.jp = instantiateVariableFont(jp, {"wght": 400})
 
-    def test_prep_table_survives_merge(self):
-        """prep table is preserved after merge."""
-        if "prep" not in self.jp:
-            pytest.skip("Base font has no prep table")
+    def test_fpgm_dropped(self):
+        """fpgm is dropped from merged TTF output."""
         m = _merge()
-        assert "prep" in m, "prep table lost during merge"
-        # Contents should match the base font
-        assert m["prep"].program.getBytecode() == self.jp["prep"].program.getBytecode(), \
-            "prep table contents differ from base font"
+        assert "fpgm" not in m, "fpgm should be stripped from merged TTF"
+
+    def test_prep_dropped(self):
+        """prep is dropped from merged TTF output."""
+        m = _merge()
+        assert "prep" not in m, "prep should be stripped from merged TTF"
+
+    def test_cvt_dropped(self):
+        """cvt is dropped from merged TTF output."""
+        m = _merge()
+        assert "cvt " not in m, "cvt should be stripped from merged TTF"
 
     def test_gasp_table_survives_merge(self):
-        """gasp table is preserved after merge."""
+        """gasp is preserved (smoothing hint, not bytecode)."""
         if "gasp" not in self.jp:
             pytest.skip("Base font has no gasp table")
         m = _merge()
         assert "gasp" in m, "gasp table lost during merge"
-        # Verify gasp ranges are preserved
         assert m["gasp"].gaspRange == self.jp["gasp"].gaspRange, \
             "gasp ranges differ from base font"
 
-    def test_latin_glyph_instructions_not_crash(self):
-        """Latin glyph hinting instructions do not crash after merge.
+    def test_glyph_programs_cleared(self):
+        """Every glyph in the merged TTF has an empty bytecode program."""
+        m = _merge(lat_scale=1.5)
+        glyf = m["glyf"]
+        for gname in m.getGlyphOrder():
+            try:
+                g = glyf[gname]
+            except KeyError:
+                continue
+            program = getattr(g, "program", None)
+            if program is None:
+                continue
+            assert len(program.bytecode) == 0, \
+                f"Glyph '{gname}' still carries {len(program.bytecode)} bytes of bytecode"
 
-        Glyph-level TT instructions may become invalid after scaling,
-        but font compilation and loading should still work.
-        """
-        m = _merge(lat_scale=1.0)
-        # Round-trip: save and reload to verify no instruction-related crash
-        out = tempfile.mktemp(suffix=".ttf")
-        try:
-            m.save(out)
-            reloaded = TTFont(out)
-            glyf = reloaded["glyf"]
-            # Verify Latin glyphs are accessible
-            for gname in ["H", "a", "zero"]:
-                g = glyf.get(gname)
-                assert g is not None, f"Glyph '{gname}' missing after round-trip"
-        finally:
-            if os.path.exists(out):
-                os.remove(out)
+    def test_maxp_hinting_fields_zeroed(self):
+        """maxp v1 hint counters are normalized in unhinted output."""
+        m = _merge()
+        maxp = m["maxp"]
+        assert maxp.maxZones == 1, "maxp.maxZones must be 1 for unhinted TrueType output"
+        for attr in (
+            "maxTwilightPoints",
+            "maxStorage",
+            "maxFunctionDefs",
+            "maxInstructionDefs",
+            "maxStackElements",
+            "maxSizeOfInstructions",
+        ):
+            if hasattr(maxp, attr):
+                assert getattr(maxp, attr) == 0, \
+                    f"maxp.{attr} = {getattr(maxp, attr)}, expected 0 for unhinted output"
 
-    def test_scaled_latin_glyph_instructions_not_crash(self):
-        """Scaled Latin glyphs do not crash on round-trip."""
+    def test_round_trip_loads_clean(self):
+        """Saved-then-reloaded TTF still has every glyph accessible."""
         m = _merge(lat_scale=1.5)
         out = tempfile.mktemp(suffix=".ttf")
         try:
             m.save(out)
             reloaded = TTFont(out)
-            # Access all glyphs to trigger instruction parsing
             glyf = reloaded["glyf"]
             for gname in reloaded.getGlyphOrder():
                 _ = glyf[gname]
@@ -1351,34 +1372,95 @@ class TestHintingPreservation:
             if os.path.exists(out):
                 os.remove(out)
 
-    def test_scaled_latin_instructions_cleared(self):
-        """Scaled Latin glyphs have their hinting instructions cleared."""
-        m = _merge(lat_scale=1.5)
-        glyf = m["glyf"]
-        # 'A' is a Latin glyph that was scaled
-        a_glyph = glyf.get("A")
-        if a_glyph and hasattr(a_glyph, "program") and a_glyph.program:
-            assert len(a_glyph.program.bytecode) == 0, \
-                "Scaled Latin glyph should have empty instructions"
+    def test_hinted_sub_font_gets_normalized(self):
+        """Hinted sub font + base merge still yields unhinted output (Issue #17)."""
+        out = tempfile.mktemp(suffix=".ttf")
+        config = {
+            "subFont": {
+                "path": TIKTOK_SANS,
+                "scale": 1.0,
+                "baselineOffset": 0,
+                "axes": [],
+            },
+            "baseFont": {
+                "path": JP_VAR,
+                "scale": 1.0,
+                "baselineOffset": 0,
+                "axes": [{"tag": "wght", "currentValue": 400}],
+            },
+            "output": {"familyName": "TestHintNormalize"},
+            "export": {"path": {"font": out}},
+        }
+        try:
+            mf.merge_fonts(config)
+            m = TTFont(out)
+            try:
+                # Bytecode tables: fully removed.
+                assert "fpgm" not in m
+                assert "prep" not in m
+                assert "cvt " not in m
+                # Sub font's Latin glyphs: bytecode stripped despite the
+                # original carrying e.g. 29 bytes on 'A'. This was the core
+                # issue — glyph bytecode survived without its companion
+                # fpgm/prep/cvt and silently did nothing.
+                glyf = m["glyf"]
+                for gname in ("A", "zero"):
+                    if gname in glyf.glyphOrder:
+                        program = getattr(glyf[gname], "program", None)
+                        if program is not None:
+                            assert len(program.bytecode) == 0, \
+                                f"Sub-font hinted glyph '{gname}' must have bytecode cleared"
+                # maxp counters reset.
+                maxp = m["maxp"]
+                assert maxp.maxZones == 1
+                for attr in ("maxFunctionDefs", "maxStorage",
+                             "maxSizeOfInstructions"):
+                    if hasattr(maxp, attr):
+                        assert getattr(maxp, attr) == 0
+            finally:
+                m.close()
+        finally:
+            if os.path.exists(out):
+                os.remove(out)
+            woff2 = out.replace(".ttf", ".woff2")
+            if os.path.exists(woff2):
+                os.remove(woff2)
 
-    def test_unscaled_latin_instructions_preserved(self):
-        """Unscaled Latin glyphs preserve hinting instructions."""
-        # UPM ratio may cause implicit scaling, so check if any instructions survive
-        # at scale=1.0. This depends on whether UPMs match.
-        m = _merge(lat_scale=1.0)
-        glyf = m["glyf"]
-        # Just verify it doesn't crash — actual preservation depends on UPM match
-        a_glyph = glyf.get("A")
-        assert a_glyph is not None
+    def test_ttfautohint_policy_requires_tool(self, monkeypatch):
+        """Explicit ttfautohint mode fails clearly when the tool is absent."""
+        monkeypatch.setattr(mf.shutil, "which", lambda name: None)
+        with pytest.raises(RuntimeError, match="ttfautohint was not found"):
+            mf._apply_ttfautohint("/tmp/nonexistent.ttf")
 
-    def test_maxp_hinting_fields_present(self):
-        """maxp table has TT hinting-related fields."""
-        m = _merge()
-        maxp = m["maxp"]
-        # TrueType maxp (version 1.0) should have these fields
-        assert hasattr(maxp, "maxZones"), "maxp missing maxZones"
-        assert hasattr(maxp, "maxFunctionDefs"), "maxp missing maxFunctionDefs"
-        assert hasattr(maxp, "maxSizeOfInstructions"), "maxp missing maxSizeOfInstructions"
+    def test_ttfautohint_policy_replaces_output(self, monkeypatch):
+        """ttfautohint mode writes a temp output, then replaces the final TTF."""
+        calls = []
+        out = tempfile.mktemp(suffix=".ttf")
+        tmp = f"{out}.ttfautohint.tmp"
+        try:
+            with open(out, "wb") as f:
+                f.write(b"before")
+
+            def fake_run(args, check, stdout, stderr):
+                calls.append((args, check, stdout, stderr))
+                assert args[1] == out
+                assert args[2] == tmp
+                with open(args[2], "wb") as f:
+                    f.write(b"after")
+
+            monkeypatch.setattr(mf.shutil, "which", lambda name: "/usr/bin/ttfautohint")
+            monkeypatch.setattr(mf.subprocess, "run", fake_run)
+
+            mf._apply_ttfautohint(out)
+
+            assert calls
+            with open(out, "rb") as f:
+                assert f.read() == b"after"
+            assert not os.path.exists(tmp)
+        finally:
+            for p in (out, tmp):
+                if os.path.exists(p):
+                    os.remove(p)
 
 
 

--- a/python/tests/test_metadata.py
+++ b/python/tests/test_metadata.py
@@ -978,9 +978,7 @@ class TestInheritUniqueId:
 
 
 class TestExportConfigMetadataMode:
-    """build_export_config must round-trip output.metadataMode so that
-    bundled package exports and path exports don't silently revert
-    inheritBase/inheritSub to the merge-mode default when reused."""
+    """build_export_config must round-trip non-identity output policies."""
 
     def test_inherit_base_preserved(self):
         config = {
@@ -1015,6 +1013,17 @@ class TestExportConfigMetadataMode:
         }
         result = mf.build_export_config(config)
         assert "metadataMode" not in result.get("output", {})
+
+    def test_hinting_policy_preserved(self):
+        """hinting policy is kept so bundled exports remain reproducible."""
+        config = {
+            "baseFont": {"path": "/fonts/base.ttf", "scale": 1.0,
+                         "baselineOffset": 0, "axes": []},
+            "output": {"hinting": "ttfautohint"},
+            "export": {"path": {"font": "/out.ttf"}},
+        }
+        result = mf.build_export_config(config)
+        assert result["output"]["hinting"] == "ttfautohint"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- normalize merged TrueType output as unhinted by stripping glyph bytecode plus fpgm/prep/cvt while keeping maxp valid
- add opt-in output.hinting=ttfautohint post-processing after the final TTF is written
- document the hinting policy and add regression coverage for hinted sub-font normalization and export-config round-tripping

## Why

Fixes #17. Mixed-source TrueType bytecode is unsafe because glyph programs depend on font-wide fpgm/prep/cvt/maxp state from the same source. The default output now avoids stale hinting state, while ttfautohint remains an explicit final-output option.

## Validation

- python3 -m pytest python/tests/ -q -> 340 passed, 1 skipped
- python3 -m pytest python/tests/test_metadata.py::TestExportConfigMetadataMode python/tests/test_glyph_data.py::TestHintingNormalization python/tests/test_pipeline.py::TestWOFF2Output -q -> 16 passed
- npm run build -> passed

## Notes

- Default behavior is strip/unhinted normalization.
- ttfautohint requires an external ttfautohint binary and fails clearly if requested but missing.
