### PR TITLE
[codex] Preserve vertical glyph data on rename

### DIFF
--- a/docs/ARCHITECTURE.ja.md
+++ b/docs/ARCHITECTURE.ja.md
@@ -158,6 +158,41 @@ base 側の codepoint (U+25CE) は元の base 字形をそのまま保持する�
 codepoint 集合がずれているなら両者は別グリフ、という前提が成り立つ
 ためで、無効化するとサイレント上書きが復活する。
 
+### グリフリネームと縦組み情報
+
+グリフ名そのものに縦組みの意味が含まれるわけではない。ただし
+fontTools 上では、グリフ名が glyph-indexed table のキーになる。
+そのため merge engine がグリフスロットをリネームまたは複製する
+場合（`.sub`, `.lat`, `.orig`）、outline と `hmtx` だけでなく、
+そのスロットを参照し続けるべき glyph-keyed table も同時に更新する
+必要がある。
+
+これは縦書きで特に問題になる。Noto Sans JP は U+2027
+(hyphenation point) と U+30FB (katakana middle dot) を同じ base
+glyph `uni2027` に割り当てている。Inter が U+2027 を置換する場合、
+merge は元の base glyph を `uni2027.orig` に複製し、U+30FB をそこへ
+向け直す。ここで outline と `hmtx` だけをコピーすると、後段の整合性
+補完で `vmtx` がデフォルト値 `(advance=UPM, topSideBearing=0)` になり、
+縦組み時に中黒が上に寄る。
+
+同じ規則は置換側グリフをリネームした場合にも適用する。たとえば
+cross-codepoint 保護によって Inter の U+2026 が `ellipsis.sub` に
+リネームされることがあるが、base 側の Noto glyph `ellipsis` は
+`vert` / `vrt2` で `ellipsis` → `uniFE19` の置換を持つ。この
+SingleSubst を `ellipsis.sub` にもコピーしないと、codepoint は残って
+いても縦組み shaping から外れる。
+
+したがって、base 由来または base codepoint と重なるリネームでは
+以下も追従させる。
+
+- `vmtx` row
+- `VORG` origin record（存在する場合）
+- `vert` / `vrt2` の SingleSubst mapping（リネームされた入力 glyph 用）
+
+リネーム戦略自体は引き続き必要である。共有 glyph slot を分割しないと、
+ある codepoint だけを置換したつもりでも、同じ base glyph を共有していた
+CJK 側の collateral codepoint を破壊してしまう。
+
 ### グリフコピー戦略
 
 | ソース → ターゲット | 方式 |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -160,6 +160,39 @@ This rename is unconditional — same glyph name with disjoint or
 partially-disjoint codepoint sets always means the two glyphs are
 unrelated, so opting out would re-expose the silent overwrite.
 
+### Glyph Renames and Vertical Layout Data
+
+Glyph names are not semantic vertical-layout markers, but they are the
+keys used by fontTools for glyph-indexed tables. When the merge engine
+renames or duplicates a glyph slot (`.sub`, `.lat`, `.orig`), every
+glyph-keyed table that should continue to describe that slot must be
+updated alongside the outline and `hmtx` row.
+
+This matters for vertical text. Noto Sans JP maps U+2027 (hyphenation
+point) and U+30FB (katakana middle dot) to the same base glyph
+`uni2027`. When Inter replaces U+2027, the merge duplicates the original
+base glyph to `uni2027.orig` and repoints U+30FB there. If only the
+outline and `hmtx` are copied, the later consistency pass backfills a
+default `vmtx` row `(advance=UPM, topSideBearing=0)`, which moves the
+middle dot too high in vertical writing.
+
+The same rule applies to renamed replacement glyphs. For example,
+cross-codepoint protection may rename Inter's U+2026 glyph to
+`ellipsis.sub`; the base Noto glyph `ellipsis` also participates in
+`vert` / `vrt2` (`ellipsis` → `uniFE19`). Without copying that
+SingleSubst mapping to `ellipsis.sub`, the replacement glyph falls out
+of vertical shaping even though the codepoint is still present.
+
+Therefore every base-derived or base-overlapping rename also carries:
+
+- `vmtx` rows
+- `VORG` origin records when present
+- `vert` / `vrt2` SingleSubst mappings for renamed inputs
+
+The rename strategy remains necessary: without splitting shared glyph
+slots, replacing one codepoint would still corrupt collateral CJK
+codepoints that happened to share the original base glyph.
+
 ### Glyph Copy Strategy
 
 | Source → Target | Method |

--- a/python/merge_fonts.py
+++ b/python/merge_fonts.py
@@ -1249,6 +1249,48 @@ def transform_tt_glyph_inplace(font: TTFont, glyph_name: str,
         hmtx.metrics[glyph_name] = (int(round(aw * scale)), int(round(lsb * scale)))
 
 
+def _copy_vertical_metrics(font: TTFont, src_name: str, dst_name: str) -> None:
+    """Copy vertical metrics from one glyph slot to another in the same font."""
+    if "vmtx" in font and src_name in font["vmtx"].metrics:
+        font["vmtx"].metrics[dst_name] = font["vmtx"].metrics[src_name]
+    if "VORG" in font:
+        vorg = font["VORG"]
+        records = getattr(vorg, "VOriginRecords", None)
+        if records is not None and src_name in records:
+            records[dst_name] = records[src_name]
+
+
+def _copy_single_substitutions_for_features(
+    font: TTFont, src_name: str, dst_name: str, feature_tags: set
+) -> None:
+    """Copy feature-scoped SingleSubst mappings from one glyph to another."""
+    gsub = font.get("GSUB")
+    if not gsub or not getattr(gsub, "table", None):
+        return
+    table = gsub.table
+    if not table.FeatureList or not table.LookupList:
+        return
+
+    for feature_record in table.FeatureList.FeatureRecord:
+        if feature_record.FeatureTag not in feature_tags:
+            continue
+        for lookup_index in feature_record.Feature.LookupListIndex:
+            lookup = table.LookupList.Lookup[lookup_index]
+            if lookup.LookupType != 1:
+                continue
+            for subtable in lookup.SubTable:
+                st = (subtable.ExtSubTable if hasattr(subtable, "ExtSubTable")
+                      else subtable)
+                mapping = getattr(st, "mapping", None)
+                if not mapping or src_name not in mapping or dst_name in mapping:
+                    continue
+                mapping[dst_name] = mapping[src_name]
+                coverage = getattr(st, "Coverage", None)
+                if (coverage and hasattr(coverage, "glyphs")
+                        and dst_name not in coverage.glyphs):
+                    coverage.glyphs.append(dst_name)
+
+
 # ---------------------------------------------------------------------------
 # TrueType hinting normalization
 # ---------------------------------------------------------------------------
@@ -3656,6 +3698,10 @@ def merge_fonts(config: dict) -> str:
                 merged["hmtx"].metrics[dup_name] = (
                     merged["hmtx"].metrics[merged_gname]
                 )
+            _copy_vertical_metrics(merged, merged_gname, dup_name)
+            _copy_single_substitutions_for_features(
+                merged, merged_gname, dup_name, {"vert", "vrt2"}
+            )
 
             # Repoint collateral cmap entries to the duplicate
             for table in merged["cmap"].tables:
@@ -3681,6 +3727,18 @@ def merge_fonts(config: dict) -> str:
         # merge writes outlines that already match the final head.unitsPerEm.
         upm_scale = output_upm / lat_upm
         final_lat_scale = lat_scale * upm_scale
+
+        vertical_metric_source_for_dst = {}
+        if "vmtx" in merged or "VORG" in merged:
+            for cp, lat_glyph_name in latin_glyphs_to_copy.items():
+                base_glyph_name = merged_cmap.get(cp)
+                if not base_glyph_name:
+                    continue
+                dst_name = lat_to_merged_name.get(lat_glyph_name, lat_glyph_name)
+                if dst_name not in existing_names:
+                    vertical_metric_source_for_dst.setdefault(
+                        dst_name, base_glyph_name
+                    )
 
         # Step 6: Copy Latin glyphs into merged font (using name mapping)
         progress("merging-glyphs", 4, f"2/{S} \u00b7 Merging glyphs...")
@@ -3800,6 +3858,13 @@ def merge_fonts(config: dict) -> str:
             convert_tt_glyphs_to_cff(lat_font, merged, unique_lat_glyphs,
                                       final_lat_scale, lat_baseline, copied,
                                       existing_names, name_map=lat_to_merged_name)
+
+        for dst_name, base_glyph_name in vertical_metric_source_for_dst.items():
+            if dst_name in existing_names:
+                _copy_vertical_metrics(merged, base_glyph_name, dst_name)
+                _copy_single_substitutions_for_features(
+                    merged, base_glyph_name, dst_name, {"vert", "vrt2"}
+                )
 
         # Sync font-level glyph order
         if merged_is_tt:

--- a/python/tests/test_glyph_data.py
+++ b/python/tests/test_glyph_data.py
@@ -1768,6 +1768,77 @@ class TestSharedGlyphCollateral:
         bounds = _get_bounds(m, cmap[0x30FB])
         assert bounds is not None, "U+30FB has no outline"
 
+    def test_replaced_glyphs_preserve_base_vertical_metrics(self):
+        """Replaced glyphs must keep their original base vmtx rows.
+
+        If a copied or duplicated glyph misses vmtx, the later consistency
+        pass backfills topSideBearing=0, which moves the glyph too high in
+        vertical text.
+        """
+        m = self._merge()
+        base = TTFont(JP_STATIC)
+        try:
+            cmap = m.getBestCmap()
+            base_cmap = base.getBestCmap()
+            for cp in (
+                0x0020, 0x002D, 0x00A0, 0x02BB, 0x0399, 0x2003,
+                0x2011, 0x2012, 0x2013, 0x2018, 0x2026, 0x24EA,
+                0x30FB, 0xFF40,
+            ):
+                merged_glyph = cmap.get(cp)
+                base_glyph = base_cmap.get(cp)
+                assert merged_glyph is not None, f"U+{cp:04X} missing"
+                assert base_glyph is not None, f"U+{cp:04X} missing in base"
+                assert m["vmtx"].metrics[merged_glyph] == (
+                    base["vmtx"].metrics[base_glyph]
+                )
+        finally:
+            base.close()
+
+    @staticmethod
+    def _single_sub_mapping_for_feature(font, feature_tag):
+        if "GSUB" not in font:
+            return {}
+        table = font["GSUB"].table
+        if not table.FeatureList or not table.LookupList:
+            return {}
+        result = {}
+        for feature_record in table.FeatureList.FeatureRecord:
+            if feature_record.FeatureTag != feature_tag:
+                continue
+            for lookup_index in feature_record.Feature.LookupListIndex:
+                lookup = table.LookupList.Lookup[lookup_index]
+                if lookup.LookupType != 1:
+                    continue
+                for subtable in lookup.SubTable:
+                    st = (subtable.ExtSubTable
+                          if hasattr(subtable, "ExtSubTable") else subtable)
+                    mapping = getattr(st, "mapping", None)
+                    if mapping:
+                        result.update(mapping)
+        return result
+
+    def test_renamed_replacements_preserve_vertical_substitution(self):
+        """Renamed replacement glyphs should stay reachable from vert/vrt2."""
+        m = self._merge()
+        base = TTFont(JP_STATIC)
+        try:
+            cmap = m.getBestCmap()
+            base_cmap = base.getBestCmap()
+            merged_glyph = cmap[0x2026]
+            base_glyph = base_cmap[0x2026]
+            assert merged_glyph != base_glyph
+
+            for tag in ("vert", "vrt2"):
+                base_mapping = self._single_sub_mapping_for_feature(base, tag)
+                merged_mapping = self._single_sub_mapping_for_feature(m, tag)
+                assert base_mapping.get(base_glyph) is not None
+                assert merged_mapping.get(merged_glyph) == (
+                    base_mapping[base_glyph]
+                )
+        finally:
+            base.close()
+
 
 
 


### PR DESCRIPTION
## Summary

- copy vmtx/VORG rows when duplicated or renamed glyph slots preserve base vertical placement
- carry vert/vrt2 SingleSubst mappings over to renamed replacement glyphs
- add regression coverage for Noto Sans JP + Inter vertical metrics and ellipsis vertical substitution
- document the glyph-rename vertical-layout policy in both Architecture docs

## Root Cause

Glyph renaming splits shared base glyph slots such as U+2027/U+30FB so one codepoint can be replaced by Inter while collateral CJK codepoints keep the base outline. The split copied outlines and hmtx, but glyph-keyed vertical data remained attached to the old name. Missing vmtx rows were later backfilled with topSideBearing=0, moving glyphs too high in vertical text; renamed glyphs could also fall out of vert/vrt2 substitutions.

## Noto Sans JP + Inter Examples

These codepoints are covered by the fix for the Noto Sans JP + Inter case:

| char | code | Unicode name |
|---|---|---|
| ・ | U+30FB | KATAKANA MIDDLE DOT |
| ｀ | U+FF40 | FULLWIDTH GRAVE ACCENT |
| Ι | U+0399 | GREEK CAPITAL LETTER IOTA |
| – | U+2013 | EN DASH |
| ‒ | U+2012 | FIGURE DASH |
| ‑ | U+2011 | NON-BREAKING HYPHEN |
| ‘ | U+2018 | LEFT SINGLE QUOTATION MARK |
| ʻ | U+02BB | MODIFIER LETTER TURNED COMMA |
| - | U+002D | HYPHEN-MINUS |
| … | U+2026 | HORIZONTAL ELLIPSIS |

## Validation

- npm run build -> passed
- npm test -> 374 passed, 1 skipped
- python3 -m pytest python/tests/test_glyph_data.py::TestSharedGlyphCollateral -q -> 6 passed
- python3 -m pytest python/tests/test_exclude_codepoints.py::TestGlyphNameCollisionRename -q -> 5 passed
- python3 -m pytest python/tests/test_glyph_data.py::TestMetricsPreservation -q -> 10 passed
- manual Noto Sans JP + Inter scan: remaining-default-vmtx-overlaps 0; ellipsis.sub maps to uniFE19 via vert/vrt2
