### PR TITLE
Strip Latin-input substitutions from base GSUB (#23)

### DIFF
--- a/docs/ARCHITECTURE.ja.md
+++ b/docs/ARCHITECTURE.ja.md
@@ -295,6 +295,49 @@ Illustrator / InDesign で「任意の合字」(`dlig`) を ON にすると、
 リガチャエントリを削除する。クロススクリプトのエントリ（入力鎖のどこかに
 CJK グリフが含まれるもの）は保持されるので、JP 側の正規リガチャは生き残る。
 
+### Latin 1入力 GSUB 置換の保持 (Issue #23)
+
+Pan-CJK ベース書体は Type 1 SingleSubst (`locl` / `fwid` / `hwid` /
+`tnum`) や Type 3 AlternateSubst (`aalt`) でも Latin の数字・文字グリフを
+ベース書体側の代替へ写すルールを持っている。#20 のクロスコードポイント
+リネーム以降、これらの lookup は `latin` ではなく `mixed` に分類されて
+merge を生き残るようになり（`ellipsis.sub` のように Latin 由来のリネーム
+グリフが Latin 集合から外れるため）、Latin テキストにベース側ルールが発火する。
+結果として `0123456789` を `latn/en` で組むと、Latin フォントの数字ではなく
+ベース書体の全角／locl 代替に化ける。
+
+`_strip_latin_owned_substitutions` は `_strip_latin_only_ligatures` の
+Type 1 / Type 3 版。生き残ったベース側 lookup の SingleSubst (`mapping`)
+／AlternateSubst (`alternates`) サブテーブルを歩き、source グリフが
+Latin フォント所有のものは削除する。`Coverage` は fontTools が compile 時に
+`mapping` / `alternates` のキーから再構築するので、辞書を更新するだけで足りる。
+
+ストリップの保護セットは意図的に狭い：**クロスコードポイントの `.sub`
+リネームだけ**を除外対象にする。Inter の `ellipsis` が Noto の U+22EF
+にある `ellipsis` と名前衝突した場合、merge エンジンは Inter 側を
+`ellipsis.sub` にリネームしてベース側の glyph を U+22EF に残す。
+`_copy_single_substitutions_for_features` がベース側の `vert` / `vrt2`
+マッピングを `ellipsis.sub` に複写するので、ストリップは `.sub` リネーム
+対象だけは保護対象として除外する（`cross_codepoint_lat_renames` として
+収集し `preserved_lat_names` で渡す）。これで U+2026 の縦書きも引き続き
+機能する。
+
+CID 系の cmap リネームは保護しない。Inter の `zero` が Noto Sans CJK で
+`cid00017` に写るのは通常の cmap 駆動リネームであって、クロスコード
+ポイントリネームではない — `cid00017 → cid63153` のようなエントリこそ
+Issue #23 のバグなので必ず削除する。同名衝突回避の `.lat` リネーム
+(`cedilla` → `cedilla.lat` 等) も保護セットに含めない：これらは cmap に
+載らない位置に居住するため vert/vrt2 のクロスコピーが走ることもない。
+
+65535 グリフ予算に当たる fallback 経路でもストリップが必要になる。
+従来は `merge_feature_tables(None, ...)` を呼んで `lat_glyph_names` が
+空のまま走らせていたため、ストリップが no-op になりベース側の Latin
+入力ルールが残っていた。修正後は `append_lat_lookups=False` と
+（budget loop と Step 4b のキャンセルを反映した *post-prune* な
+`all_lat_glyphs` 由来の）`lat_glyph_names_override` を渡すので、
+Latin GSUB の append が無理でも、実際にコピーされた Latin グリフ名に
+対するベース側ルールはストリップされる。
+
 ### `ccmp` の重複タグ排除
 
 kern を `latn` 配下で壊していた shadowing パターン（HarfBuzz は重複タグの

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -298,6 +298,51 @@ lookups and drops every ligature entry whose first input *and* every
 Component glyph is in the Latin font. Cross-script entries (any CJK input
 in the chain) are preserved so JP keeps its legitimate ligatures.
 
+### Latin Single-Glyph Substitution Preservation (Issue #23)
+
+Pan-CJK base fonts also ship Latin-script Type 1 SingleSubst (`locl`,
+`fwid`, `hwid`, `tnum`) and Type 3 AlternateSubst (`aalt`) lookups that
+map Latin digit / letter glyphs to base-font alternates. After the
+cross-codepoint rename in #20, these lookups can be classified `mixed`
+rather than `latin` (because at least one Latin-renamed glyph like
+`ellipsis.sub` is no longer in the Latin set), so they survive merging.
+The base rule then fires on Latin text — plain `0123456789` under
+`latn/en` shapes to base-font full-width / locl alternates instead of the
+Latin font's digits.
+
+`_strip_latin_owned_substitutions` is the Type 1 / Type 3 analogue of
+`_strip_latin_only_ligatures`. It walks SingleSubst (`mapping`) and
+AlternateSubst (`alternates`) subtables in surviving base-side lookups
+and drops entries whose source glyph is owned by the Latin font.
+fontTools rebuilds `Coverage` from the surviving keys at compile time,
+so updating the dicts is sufficient.
+
+The strip's preservation set is narrow on purpose: only **cross-codepoint
+`.sub` renames** opt out of stripping. When Inter's `ellipsis` collides
+with Noto's `ellipsis` at U+22EF, the merge engine renames Inter's to
+`ellipsis.sub` so the base glyph survives at U+22EF. `ellipsis.sub` then
+inherits base's `vert` / `vrt2` mapping via
+`_copy_single_substitutions_for_features`. The strip explicitly excludes
+those `.sub` rename targets (tracked as `cross_codepoint_lat_renames`
+and threaded through as `preserved_lat_names`) so vertical layout still
+works at U+2026.
+
+CID cmap remap is *not* preserved. Inter's `zero` becoming `cid00017`
+for Noto Sans CJK is a normal cmap-driven name remap, not a
+cross-codepoint rename — those entries are exactly the bug case
+(`cid00017 → cid63153`) and must be stripped. Same-name `.lat` collision
+renames (`cedilla` → `cedilla.lat`) are also not in the preservation
+set: their renamed form lives at a non-cmap address and never receives a
+vert/vrt2 cross-copy.
+
+The 65535-glyph budget fallback path also needs the strip. Previously it
+called `merge_feature_tables(None, ...)`, leaving `lat_glyph_names`
+empty so nothing was stripped. The fallback now passes a
+`lat_glyph_names_override` derived from the *post-prune* `all_lat_glyphs`
+together with `append_lat_lookups=False`, so base lookups on
+already-copied Latin glyphs get cleaned even when the Latin GSUB lookups
+themselves can't be appended.
+
 ### `ccmp` Duplicate-Tag Dedupe
 
 The same shadowing pattern that broke kern under `latn` (HarfBuzz picks

--- a/python/merge_fonts.py
+++ b/python/merge_fonts.py
@@ -1802,6 +1802,57 @@ def _strip_latin_only_ligatures(lookup, lat_glyph_names: set):
         st.ligatures = new_ligatures
 
 
+def _strip_latin_owned_substitutions(lookup, lat_glyph_names: set,
+                                     preserved_lat_names: set = None):
+    """Drop Type 1 / Type 3 GSUB entries whose source glyph is Latin-owned.
+
+    Pan-CJK fonts (Noto Sans JP, Noto Sans CJK JP, …) ship Latin-script
+    `locl`, `aalt`, `fwid`, `hwid`, `tnum` lookups that map Latin digit /
+    letter glyphs to base-font alternates. After cross-codepoint glyph
+    rename (#20) the base-side reference set drifts so the lookup is
+    classified `mixed` rather than `latin`, and the rule survives the
+    merge. Once it survives, plain ``0123456789`` shaped under
+    ``latn/en`` shapes to base-font full-width / locl alternates instead
+    of the Latin font's digits — even when no `fwid` / `tnum` was asked
+    for, because the base-side `locl` rewrites the input first.
+
+    This is the GSUB Type 1 / Type 3 analogue of
+    ``_strip_latin_only_ligatures`` and ``_strip_latin_first_from_pairpos``.
+    Walk surviving base-side SingleSubst (Type 1) and AlternateSubst
+    (Type 3) subtables and drop entries whose source glyph is owned by
+    the Latin font. Cross-script entries (source glyph CJK-owned) are
+    preserved so JP-only behavior such as ``vert`` / ``vrt2`` keeps
+    firing on Japanese glyphs.
+
+    ``preserved_lat_names`` lists Latin glyph names the merge engine
+    renamed during cross-codepoint preservation (e.g. Inter's ``ellipsis``
+    → ``ellipsis.sub`` so Noto's ``ellipsis`` at U+22EF survives). Those
+    renamed glyphs sit at non-Latin codepoints in the merged font and
+    inherit base-side ``vert`` / ``vrt2`` mappings via
+    ``_copy_single_substitutions_for_features``; stripping them would
+    silently kill the inherited behavior.
+
+    fontTools rebuilds Coverage from the surviving ``mapping`` /
+    ``alternates`` keys at compile time, so updating those dicts is
+    sufficient.
+    """
+    if not lat_glyph_names:
+        return
+    preserve = preserved_lat_names or set()
+    for subtable in lookup.SubTable:
+        st = subtable
+        if hasattr(st, 'ExtSubTable'):
+            st = st.ExtSubTable
+        for attr in ('mapping', 'alternates'):
+            data = getattr(st, attr, None)
+            if not data:
+                continue
+            stripped = {g: v for g, v in data.items()
+                        if g not in lat_glyph_names or g in preserve}
+            if len(stripped) != len(data):
+                setattr(st, attr, stripped)
+
+
 def _strip_latin_first_from_pairpos(lookup, lat_glyph_names: set):
     """Drop Latin first-position glyphs from PairPos subtables.
 
@@ -1851,7 +1902,10 @@ def _strip_latin_first_from_pairpos(lookup, lat_glyph_names: set):
 
 def merge_feature_tables(lat_font: TTFont, jp_font: TTFont, merged: TTFont,
                          lat_scale: float = 1.0, lat_baseline: float = 0,
-                         lat_name_map: dict = None):
+                         lat_name_map: dict = None,
+                         append_lat_lookups: bool = True,
+                         preserved_lat_names: set = None,
+                         lat_glyph_names_override: set = None):
     """
     Merge GSUB/GPOS tables with correct feature separation.
 
@@ -1862,16 +1916,37 @@ def merge_feature_tables(lat_font: TTFont, jp_font: TTFont, merged: TTFont,
         because the merged slot for U+0041 is ``A``), the Latin GSUB/GPOS
         lookup glyph references must be rewritten to match so that features
         like ``calt`` keep working.
+    append_lat_lookups: when ``False``, the Latin font's GSUB/GPOS lookups
+        are NOT appended to the merged tables, but the Latin-owned glyph
+        name set is still computed and used to strip base-side mixed
+        lookups (so e.g. base ``locl`` rules on Latin digits get removed).
+        Used by the 65535-glyph budget fallback path: Latin lookups can't
+        be appended because some Latin glyphs were dropped, but base-side
+        leakage onto the digits that *did* fit must still be cleaned up.
+    preserved_lat_names: Latin merged names that the cross-codepoint
+        rename pass produced (e.g. ``ellipsis.sub``). Excluded from the
+        base-side strip so the inherited ``vert`` / ``vrt2`` mappings
+        added by ``_copy_single_substitutions_for_features`` survive.
+    lat_glyph_names_override: explicit Latin-owned merged-name set. Used
+        on the budget fallback path where some Latin glyphs were dropped
+        (so ``lat_font.getGlyphOrder()`` overstates the actually-copied
+        set). Stripping a dropped name would over-eagerly remove
+        legitimate base-side rules whose source glyph is still owned by
+        the base font.
     """
     # Remap Latin glyph names so JP lookup classification and Latin lookup
     # references both line up with the *merged* glyph space.
-    if lat_font and lat_name_map:
+    if lat_glyph_names_override is not None:
+        lat_glyph_names = lat_glyph_names_override
+    elif lat_font and lat_name_map:
         lat_glyph_names = {lat_name_map.get(g, g) for g in lat_font.getGlyphOrder()}
     else:
         lat_glyph_names = set(lat_font.getGlyphOrder()) if lat_font else set()
+    preserved_lat_names = preserved_lat_names or set()
 
     for table_tag in ('GSUB', 'GPOS'):
-        lat_table = lat_font.get(table_tag) if lat_font else None
+        lat_table = lat_font.get(table_tag) if (
+            lat_font and append_lat_lookups) else None
         jp_table = merged.get(table_tag)
 
         # If we need to rename Latin glyphs, deep-copy the Latin table first
@@ -1889,12 +1964,32 @@ def merge_feature_tables(lat_font: TTFont, jp_font: TTFont, merged: TTFont,
             continue
 
         if not lat_table:
+            # Even when we aren't appending Latin lookups (budget path) or
+            # there's no Latin GSUB/GPOS at all, base-side mixed lookups
+            # may reference Latin-owned glyph names that the merge engine
+            # placed at base codepoints (cmap CID remap, same-name
+            # overwrite). Drop the lookups that are wholly Latin-input
+            # first, then strip Latin-source entries out of the surviving
+            # mixed lookups. Reversing the order would leave the wholly-
+            # Latin lookups around as empty husks — `_classify_lookup`
+            # treats an empty lookup as ``mixed``, not ``latin``, so it
+            # would no longer be eligible for removal.
             _filter_subordinate_lookups(jp_table, lat_glyph_names)
+            if lat_glyph_names and jp_table and jp_table.table \
+                    and jp_table.table.LookupList:
+                for lookup in jp_table.table.LookupList.Lookup:
+                    if table_tag == 'GSUB':
+                        _strip_latin_only_ligatures(lookup, lat_glyph_names)
+                        _strip_latin_owned_substitutions(
+                            lookup, lat_glyph_names, preserved_lat_names)
+                    elif table_tag == 'GPOS':
+                        _strip_latin_first_from_pairpos(lookup, lat_glyph_names)
             continue
 
         _merge_ot_table_v2(lat_table, jp_table, lat_font, jp_font, merged,
                            table_tag, lat_glyph_names,
-                           lat_scale=lat_scale, lat_baseline=lat_baseline)
+                           lat_scale=lat_scale, lat_baseline=lat_baseline,
+                           preserved_lat_names=preserved_lat_names)
 
 
 def _filter_subordinate_lookups(table, lat_glyph_names: set):
@@ -2112,7 +2207,8 @@ def _build_lang_sys(jp_lang_sys, lat_lang_sys, script_tag, table_tag,
 
 def _merge_ot_table_v2(lat_table, jp_table, lat_font, jp_font, merged,
                        table_tag, lat_glyph_names: set,
-                       lat_scale: float = 1.0, lat_baseline: float = 0):
+                       lat_scale: float = 1.0, lat_baseline: float = 0,
+                       preserved_lat_names: set = None):
     """
     Merge Latin and Japanese GSUB/GPOS tables.
 
@@ -2158,6 +2254,8 @@ def _merge_ot_table_v2(lat_table, jp_table, lat_font, jp_font, merged,
         elif table_tag == 'GSUB':
             for lookup in filtered_jp_lookups:
                 _strip_latin_only_ligatures(lookup, lat_glyph_names)
+                _strip_latin_owned_substitutions(
+                    lookup, lat_glyph_names, preserved_lat_names)
 
     # --- Step 2: Build merged lookup list ---
     lat_offset = len(filtered_jp_lookups)
@@ -3537,6 +3635,16 @@ def merge_fonts(config: dict) -> str:
         reserved_for_rename = (set(existing_names)
                                | set(lat_to_merged_name.values())
                                | all_lat_glyphs)
+        # Track only the *cross-codepoint* .sub renames here. The base-side
+        # GSUB strip later excludes these names from removal because
+        # `_copy_single_substitutions_for_features` will add their inherited
+        # `vert` / `vrt2` mappings after the strip runs (e.g. Inter's
+        # ``ellipsis`` → ``ellipsis.sub`` keeps base's ``ellipsis`` vert
+        # rule reachable for U+22EF). CID-style cmap remaps (e.g. Inter's
+        # ``zero`` → ``cid00017``) must NOT be in this set — those are the
+        # bug cases where base ``locl: cid00017 → cid63153`` should be
+        # stripped.
+        cross_codepoint_lat_renames: set = set()
         for sub_gname, sub_cps in sub_reverse_cmap.items():
             if sub_gname in lat_to_merged_name:
                 continue
@@ -3551,6 +3659,7 @@ def merge_fonts(config: dict) -> str:
                     new_name = f"{sub_gname}.sub{i}"
                 lat_to_merged_name[sub_gname] = new_name
                 reserved_for_rename.add(new_name)
+                cross_codepoint_lat_renames.add(new_name)
                 stranded = sorted(base_cps - sub_cps)
                 stranded_repr = ", ".join(f"U+{c:04X}" for c in stranded[:6])
                 if len(stranded) > 6:
@@ -3911,13 +4020,31 @@ def merge_fonts(config: dict) -> str:
         # CID case like Noto CJK), the Latin lookups would reference
         # non-existent glyphs. In that case, fall back to base-font-only
         # features to keep the output valid.
+        # Build the Latin-owned merged-name set from the *post-prune*
+        # ``all_lat_glyphs``, not ``lat_font.getGlyphOrder()``. The budget
+        # loop and the Step 4b collateral-cancel can both prune entries,
+        # and using the unpruned set would mark dropped / cancelled
+        # glyphs as Latin-owned — over-eagerly stripping legitimate base
+        # behavior on them.
+        lat_owned = {lat_to_merged_name.get(g, g) for g in all_lat_glyphs}
         if lat_glyphs_dropped:
+            # Latin lookups reference non-existent (dropped) glyphs and
+            # cannot be appended, but base-side ``locl`` / ``aalt`` /
+            # ``fwid`` rules on Latin-owned names must still be stripped
+            # — otherwise NotoSansCJKjp's ``cid00017 → cid63153`` (the
+            # bug case from #23) survives and plain digits shape to base
+            # CJK alternates.
             merge_feature_tables(None, jp_font, merged,
-                                 lat_scale=final_lat_scale, lat_baseline=lat_baseline)
+                                 lat_scale=final_lat_scale, lat_baseline=lat_baseline,
+                                 append_lat_lookups=False,
+                                 preserved_lat_names=cross_codepoint_lat_renames,
+                                 lat_glyph_names_override=lat_owned)
         else:
             merge_feature_tables(lat_font, jp_font, merged,
                                  lat_scale=final_lat_scale, lat_baseline=lat_baseline,
-                                 lat_name_map=lat_to_merged_name or None)
+                                 lat_name_map=lat_to_merged_name or None,
+                                 preserved_lat_names=cross_codepoint_lat_renames,
+                                 lat_glyph_names_override=lat_owned)
 
     # Step 7: Apply transforms to Japanese glyphs (always, even without Latin font)
     if (jp_scale_eff != 1.0 or jp_baseline_eff != 0) and not _jp_transform_done:

--- a/python/tests/test_glyph_data.py
+++ b/python/tests/test_glyph_data.py
@@ -9,8 +9,8 @@ from fontTools.pens.boundsPen import BoundsPen
 from fontTools.ttLib import TTFont
 
 from conftest import (
-    EN_CFF, EN_FULL, EN_VAR, JP_FULL_VAR, JP_OTF, JP_STATIC, JP_VAR,
-    KAISEI, PLAYWRITE, TIKTOK_SANS,
+    EN_CFF, EN_FULL, EN_VAR, JP_FULL_VAR, JP_OTF, JP_OTF_FULL,
+    JP_STATIC, JP_VAR, KAISEI, PLAYWRITE, TIKTOK_SANS,
     _cid_glyph_for_codepoint, _get_bounds, _merge, _merge_cff_to_cff,
 )
 
@@ -755,6 +755,448 @@ class TestLatinLigaturePreservation:
             f"{offending[:5]}"
         )
 
+
+
+# ---------------------------------------------------------------------------
+# Latin digit / single-input substitution preservation
+# ---------------------------------------------------------------------------
+
+class TestLatinSingleSubstPreservation:
+    """Pan-CJK base fonts (Noto Sans JP, Noto Sans CJK JP) ship Latin-script
+    `locl`, `aalt`, `fwid`, `hwid` lookups that map Latin digit / letter
+    glyphs to base-font alternates. After cross-codepoint glyph rename
+    (#20) the lookups are classified `mixed` instead of `latin` and survive
+    the merge — so plain ``0123456789`` shaped under ``latn/en`` shapes to
+    base-font digits instead of the Latin font's. The merge engine must
+    strip those Latin-input single-glyph substitutions so the Latin font
+    owns its own digit / letter decisions; cross-script entries on JP
+    glyphs (e.g. ``vert`` / ``vrt2``) stay reachable.
+    """
+
+    DIGITS = "0123456789"
+
+    @pytest.fixture(scope="class")
+    def inter_merged_path(self, tmp_path_factory):
+        out = tmp_path_factory.mktemp("digit_inter") / "merged.ttf"
+        config = {
+            "subFont": {
+                "path": EN_VAR,
+                "scale": 1.0,
+                "baselineOffset": 0,
+                "axes": [
+                    {"tag": "opsz", "currentValue": 14},
+                    {"tag": "wght", "currentValue": 400},
+                ],
+            },
+            "baseFont": {
+                "path": JP_VAR,
+                "scale": 1.0,
+                "baselineOffset": 0,
+                "axes": [{"tag": "wght", "currentValue": 400}],
+            },
+            "output": {"familyName": "TestDigitInter"},
+            "export": {"path": {"font": str(out)}},
+        }
+        mf.merge_fonts(config)
+        return str(out)
+
+    @pytest.fixture(scope="class")
+    def tiktok_merged_path(self, tmp_path_factory):
+        out = tmp_path_factory.mktemp("digit_tiktok") / "merged.ttf"
+        config = {
+            "subFont": {
+                "path": TIKTOK_SANS,
+                "scale": 1.0,
+                "baselineOffset": 0,
+                "axes": [],
+            },
+            "baseFont": {
+                "path": JP_VAR,
+                "scale": 1.0,
+                "baselineOffset": 0,
+                "axes": [{"tag": "wght", "currentValue": 400}],
+            },
+            "output": {"familyName": "TestDigitTikTok", "upm": 1000},
+            "export": {"path": {"font": str(out)}},
+        }
+        mf.merge_fonts(config)
+        return str(out)
+
+    def _shape(self, font_path, text, features=None,
+               script="latn", language="en"):
+        try:
+            import uharfbuzz as hb
+        except ImportError:
+            pytest.skip("uharfbuzz not installed")
+        with open(font_path, "rb") as f:
+            data = f.read()
+        face = hb.Face(data)
+        font = hb.Font(face)
+        order = TTFont(font_path).getGlyphOrder()
+        buf = hb.Buffer()
+        buf.add_str(text)
+        buf.script = script
+        buf.language = language
+        buf.guess_segment_properties()
+        hb.shape(font, buf, features or {})
+        return [order[g.codepoint] for g in buf.glyph_infos]
+
+    # Glyph indices the issue calls out as known-bad base-font digit
+    # outputs in the JP subset (lookups 1/4/5 in ``NotoSansJP-subset.ttf``
+    # before the fix). Any of these appearing for plain ``0123456789``
+    # under ``latn/en`` means base-side substitutions leaked through.
+    BASE_DIGIT_LEAKS = frozenset(
+        {f"glyph{n:05d}" for n in range(225, 235)}     # fwid digits
+        | {f"glyph{n:05d}" for n in range(320, 330)}   # hwid digits
+    )
+
+    @pytest.mark.parametrize("features,reason", [
+        (None, "default shaping"),
+        ({"tnum": True}, "tnum=1"),
+        ({"fwid": True}, "fwid=1"),
+        ({"hwid": True}, "hwid=1"),
+        ({"aalt": True}, "aalt=1"),
+        ({"locl": True}, "locl=1"),
+    ])
+    def test_inter_latn_digits_no_base_leak(
+            self, inter_merged_path, features, reason):
+        """Inter + Noto Sans JP: digits shaped under ``latn/en`` (with or
+        without ``tnum`` / ``fwid`` / ``hwid`` / ``aalt`` / ``locl``) must
+        not produce any base-font full-width / half-width digit glyph.
+
+        Pre-fix this would shape ``0`` to ``glyph00225`` (base fwid) or
+        ``glyph00320`` (base hwid) under several feature combinations.
+        """
+        shaped = self._shape(inter_merged_path, self.DIGITS, features)
+        leaked = [g for g in shaped if g in self.BASE_DIGIT_LEAKS]
+        assert not leaked, (
+            f"{reason} on Inter+NotoSansJP leaked base digit glyphs: "
+            f"{leaked} (full shape: {shaped})"
+        )
+
+    def test_inter_latn_digits_default_are_inter(self, inter_merged_path):
+        """Default ``latn/en`` shaping must reach Inter's literal ``zero``,
+        ``one``, …, ``nine`` glyph names — not any base-font alternate.
+        """
+        shaped = self._shape(inter_merged_path, self.DIGITS)
+        expected = ["zero", "one", "two", "three", "four", "five",
+                    "six", "seven", "eight", "nine"]
+        assert shaped == expected, f"merged default shaping: {shaped}"
+
+    def test_inter_latn_tnum_reaches_inter_tabular(self, inter_merged_path):
+        """``tnum=1`` on Inter + Noto Sans JP must reach Inter's tabular
+        figures (``zero.tf``..``nine.tf`` in the unsubset font, renamed
+        to ``glyph00080``..``glyph00089`` in this subset). Pre-fix,
+        base-side `locl` (or `aalt` / `fwid`) rewrote the digits to
+        base-font glyphs *before* Inter's `tnum` ran, so Inter's `tnum`
+        silently no-op'd, leaving merged tnum identical to merged default.
+
+        Compare merged tnum vs Inter solo tnum, normalizing the ``.lat``
+        suffix the merge engine appends when an Inter glyph name collides
+        with a base-font glyph (Inter's ``glyph00081`` collides with Noto
+        Sans JP's, so it becomes ``glyph00081.lat``).
+        """
+        merged_default = self._shape(inter_merged_path, self.DIGITS)
+        merged_tnum = self._shape(inter_merged_path, self.DIGITS,
+                                  {"tnum": True})
+        solo_tnum = self._shape(EN_VAR, self.DIGITS, {"tnum": True})
+
+        def normalize(g):
+            return g[:-4] if g.endswith(".lat") else g
+
+        assert merged_tnum != merged_default, (
+            f"tnum=1 silently no-op'd — Inter's tnum did not reach the "
+            f"buffer (default={merged_default} tnum={merged_tnum})"
+        )
+        assert [normalize(g) for g in merged_tnum] == solo_tnum, (
+            f"merged tnum={merged_tnum} (normalized: "
+            f"{[normalize(g) for g in merged_tnum]}) "
+            f"!= Inter solo tnum={solo_tnum}"
+        )
+
+    def test_tiktok_latn_digits_no_base_leak(self, tiktok_merged_path):
+        """Non-Inter regression: TikTok Sans + Noto Sans JP digits under
+        ``latn/en`` (default and ``tnum=1``) must not leak base digit
+        glyphs."""
+        for features, label in [(None, "default"), ({"tnum": True}, "tnum")]:
+            shaped = self._shape(tiktok_merged_path, self.DIGITS, features)
+            leaked = [g for g in shaped if g in self.BASE_DIGIT_LEAKS]
+            assert not leaked, (
+                f"TikTok {label} leaked base digit glyphs: {leaked} "
+                f"(full shape: {shaped})"
+            )
+
+    def test_tiktok_latn_digits_default_match_solo(self, tiktok_merged_path):
+        """TikTok Sans default ``latn/en`` digit shaping must equal solo
+        — TikTok and Noto Sans JP share no digit glyph names that get
+        rename-suffixed in this subset, so a direct equality check works.
+        """
+        merged = self._shape(tiktok_merged_path, self.DIGITS)
+        solo = self._shape(TIKTOK_SANS, self.DIGITS)
+        assert merged == solo, (
+            f"TikTok default: merged={merged} vs solo={solo}"
+        )
+
+    def test_no_latin_input_in_base_singlesubst(self, inter_merged_path):
+        """Structural: no surviving base-side Type 1 / Type 3 subtable
+        should map a Latin-owned digit (``zero``..``nine``) to a base-font
+        glyph. The bug: Noto Sans JP `locl` (Type 1 SingleSubst) and `aalt`
+        (Type 3 AlternateSubst) keep mappings like ``zero -> glyph00225``
+        on Latin-input names that the Latin font now owns.
+
+        Latin-origin lookups (the sub-font's own `locl` / `aalt` / `tnum`)
+        are tolerated — digits are legitimate Latin sources for those —
+        so the test only flags subtables whose outputs include glyphs the
+        Latin font does *not* know about, identifying the rule as
+        base-side.
+        """
+        merged = TTFont(inter_merged_path)
+        # Latin-owned merged glyph names — anything named in Inter solo
+        # plus the rename-suffix variants the merge engine introduces on
+        # name collisions. We only need a *superset* here: false negatives
+        # in this set would mistakenly clear a Latin output, preventing
+        # the lookup from registering as base-side; false positives are
+        # harmless. Keep the set conservative.
+        lat_solo = set(TTFont(EN_VAR).getGlyphOrder())
+        merged_glyphs = set(merged.getGlyphOrder())
+        lat_owned = {g for g in merged_glyphs
+                     if g in lat_solo or g.endswith(".lat")
+                     or g.rsplit(".", 1)[0] in lat_solo}
+        digit_inputs = {"zero", "one", "two", "three", "four",
+                        "five", "six", "seven", "eight", "nine"}
+        gsub = merged["GSUB"].table
+        offending = []
+        for li, lk in enumerate(gsub.LookupList.Lookup):
+            for sti, st in enumerate(lk.SubTable):
+                ext = st.ExtSubTable if hasattr(st, "ExtSubTable") else st
+                for attr in ("mapping", "alternates"):
+                    data = getattr(ext, attr, None)
+                    if not data:
+                        continue
+                    # Output set for this subtable. If at least one output
+                    # is a glyph the Latin font does not own, the
+                    # subtable is base-side.
+                    outs = set()
+                    for v in data.values():
+                        if isinstance(v, (list, tuple)):
+                            outs.update(v)
+                        else:
+                            outs.add(v)
+                    if outs and outs.issubset(lat_owned):
+                        continue  # Latin-origin subtable
+                    for src in data:
+                        if src in digit_inputs:
+                            offending.append(
+                                (li, sti, attr, src, data[src]))
+        assert not offending, (
+            "Base-side Type 1/3 GSUB still maps Latin digit inputs "
+            f"to base-font outputs: {offending[:10]}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# CID base font: digit substitution leakage (NotoSansCJKjp-style)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(
+    not os.path.exists(JP_OTF),
+    reason="NotoSansCJKjp-subset.otf not present",
+)
+class TestCidBaseDigitNoLeak:
+    """CID base fonts (NotoSansCJKjp / Source Han Sans) reference Latin
+    digits by CID name (e.g. ``cid00017`` for U+0030). Inter's `zero`
+    glyph is renamed to ``cid00017`` during cmap-driven copy, so the
+    base GSUB rules ``cid00017 -> cid63153`` (`locl`), ``cid00017 ->
+    cid59062`` (`fwid`) etc. all fire on the Latin design unless the
+    merge engine strips them. This test pins the regression for #23 on
+    the CID/CFF path — the bare TTF subset path uses semantic glyph
+    names and doesn't catch this CID-specific failure mode.
+    """
+
+    DIGITS = "0123456789"
+
+    @pytest.fixture(scope="class")
+    def merged_path(self, tmp_path_factory):
+        out = tmp_path_factory.mktemp("digit_cid") / "merged.otf"
+        config = {
+            "subFont": {
+                "path": EN_CFF,
+                "scale": 1.0,
+                "baselineOffset": 0,
+                "axes": [],
+            },
+            "baseFont": {
+                "path": JP_OTF,
+                "scale": 1.0,
+                "baselineOffset": 0,
+                "axes": [],
+            },
+            "output": {"familyName": "TestDigitCid"},
+            "export": {"path": {"font": str(out)}},
+        }
+        mf.merge_fonts(config)
+        return str(out)
+
+    def _shape(self, font_path, text, features=None):
+        try:
+            import uharfbuzz as hb
+        except ImportError:
+            pytest.skip("uharfbuzz not installed")
+        with open(font_path, "rb") as f:
+            data = f.read()
+        face = hb.Face(data)
+        font = hb.Font(face)
+        order = TTFont(font_path).getGlyphOrder()
+        buf = hb.Buffer()
+        buf.add_str(text)
+        buf.script = "latn"
+        buf.language = "en"
+        buf.guess_segment_properties()
+        hb.shape(font, buf, features or {})
+        return [order[g.codepoint] for g in buf.glyph_infos]
+
+    @pytest.mark.parametrize("features,reason", [
+        (None, "default"),
+        ({"locl": True}, "locl=1"),
+        ({"tnum": True}, "tnum=1"),
+        ({"fwid": True}, "fwid=1"),
+        ({"hwid": True}, "hwid=1"),
+        ({"aalt": True}, "aalt=1"),
+    ])
+    def test_cid_digits_no_base_alternate_leak(
+            self, merged_path, features, reason):
+        """For each feature combination, the merged font's digit shaping
+        under ``latn/en`` must produce stable CID digit names — not the
+        base font's full-width / half-width / locl alternate CIDs.
+
+        The merged Latin digits live at ``cid00017``..``cid00026``. The
+        bug case from the issue: base ``locl`` rewrites those to
+        ``cid63153``..``cid63162`` (and similar large-CID alternates).
+        After the fix, no entry in the base GSUB should map any of
+        ``cid00017``..``cid00026`` to a different CID, so all six feature
+        combinations shape to the same merged digit CIDs.
+        """
+        shaped = self._shape(merged_path, self.DIGITS, features)
+        latin_cids = {f"cid{n:05d}" for n in range(17, 27)}  # cid00017..00026
+        unexpected = [g for g in shaped if g not in latin_cids]
+        assert not unexpected, (
+            f"{reason} on Inter+NotoSansCJKjp leaked non-Latin CIDs: "
+            f"{unexpected} (full shape: {shaped})"
+        )
+
+    def test_cid_locl_lookup_stripped_for_latin_cids(self, merged_path):
+        """Structural: no surviving base-side Type 1 / Type 3 subtable
+        should keep ``cid00017``..``cid00026`` as a source key. Those CID
+        names are now Latin-owned (Inter's digit glyphs sit there) and
+        any base-side rewrite is the bug from #23."""
+        merged = TTFont(merged_path)
+        latin_cids = {f"cid{n:05d}" for n in range(17, 27)}
+        gsub = merged["GSUB"].table
+        offending = []
+        for li, lk in enumerate(gsub.LookupList.Lookup):
+            for sti, st in enumerate(lk.SubTable):
+                ext = st.ExtSubTable if hasattr(st, "ExtSubTable") else st
+                for attr in ("mapping", "alternates"):
+                    data = getattr(ext, attr, None)
+                    if not data:
+                        continue
+                    for src in data:
+                        if src in latin_cids:
+                            offending.append(
+                                (li, sti, attr, src, data[src]))
+        assert not offending, (
+            "Base-side Type 1/3 GSUB still maps Latin CID digits "
+            f"(cid00017..cid00026) to alternates: {offending[:10]}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# CID base font: budget-path digit leak (full NotoSansCJKjp-Regular.otf)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(
+    not os.path.exists(JP_OTF_FULL),
+    reason="NotoSansCJKjp-Regular.otf not present",
+)
+class TestCidBudgetPathDigitNoLeak:
+    """The 65535-glyph budget fallback path (`merge_feature_tables(None,
+    ...)`) used to skip base-side Latin-source stripping entirely because
+    `lat_glyph_names` was empty there. Result: full NotoSansCJKjp-Regular
+    + Inter shaped ``0123456789`` to ``cid63153..cid63162`` (locl
+    alternates). This test pins the regression on the actual budget path
+    by merging the unsubsetted Noto Sans CJK JP. It's slow (~10–30 s),
+    so it's class-scoped and only runs when the full font fixture is
+    available.
+    """
+
+    DIGITS = "0123456789"
+
+    @pytest.fixture(scope="class")
+    def merged_path(self, tmp_path_factory):
+        out = tmp_path_factory.mktemp("digit_cid_budget") / "merged.otf"
+        config = {
+            "subFont": {
+                "path": EN_CFF,
+                "scale": 1.0,
+                "baselineOffset": 0,
+                "axes": [],
+            },
+            "baseFont": {
+                "path": JP_OTF_FULL,
+                "scale": 1.0,
+                "baselineOffset": 0,
+                "axes": [],
+            },
+            "output": {"familyName": "TestDigitCidBudget"},
+            "export": {"path": {"font": str(out)}},
+        }
+        mf.merge_fonts(config)
+        return str(out)
+
+    def _shape(self, font_path, text, features=None):
+        try:
+            import uharfbuzz as hb
+        except ImportError:
+            pytest.skip("uharfbuzz not installed")
+        with open(font_path, "rb") as f:
+            data = f.read()
+        face = hb.Face(data)
+        font = hb.Font(face)
+        order = TTFont(font_path).getGlyphOrder()
+        buf = hb.Buffer()
+        buf.add_str(text)
+        buf.script = "latn"
+        buf.language = "en"
+        buf.guess_segment_properties()
+        hb.shape(font, buf, features or {})
+        return [order[g.codepoint] for g in buf.glyph_infos]
+
+    def test_full_cid_default_digits_are_latin(self, merged_path):
+        """Default ``latn/en`` digit shaping on the full NotoSansCJKjp
+        merge must reach Latin-owned CID slots, not base ``cidNNNN``
+        alternates with names that hint at vertical / fullwidth /
+        locl variants (cid63153..cid63162 for Noto Sans CJK locl).
+        """
+        shaped = self._shape(merged_path, self.DIGITS)
+        leak_cids = {f"cid{n:05d}" for n in range(63153, 63163)}
+        leaked = [g for g in shaped if g in leak_cids]
+        assert not leaked, (
+            f"Default latn/en digits leaked Noto CJK locl alternates: "
+            f"{leaked} (full shape: {shaped})"
+        )
+
+    def test_full_cid_tnum_digits_no_leak(self, merged_path):
+        """``tnum=1`` on the full CJK budget path must also avoid the
+        locl leak. ``tnum`` is the visible trigger from the issue
+        report: it makes the leak observable even when default shaping
+        looks right by accident."""
+        shaped = self._shape(merged_path, self.DIGITS, {"tnum": True})
+        leak_cids = {f"cid{n:05d}" for n in range(63153, 63163)}
+        leaked = [g for g in shaped if g in leak_cids]
+        assert not leaked, (
+            f"tnum=1 latn/en leaked Noto CJK locl alternates: "
+            f"{leaked} (full shape: {shaped})"
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #23 — base-side `locl` / `aalt` / `fwid` / `hwid` SingleSubst (Type 1) and AlternateSubst (Type 3) lookups in pan-CJK fonts (Noto Sans JP, NotoSansCJKjp) survived the merge after the cross-codepoint glyph rename in #20 and shaped Latin input glyphs to base-font alternates. Plain `0123456789` under `latn/en` shaped to base-font full-width / locl digits instead of the Latin font's digits.

- New `_strip_latin_owned_substitutions` is the Type 1/3 analogue of `_strip_latin_only_ligatures`. Walks surviving base-side subtables and drops `mapping` / `alternates` entries whose source glyph is owned by the Latin font. Coverage is rebuilt from the surviving keys at compile time.
- Cross-codepoint `.sub` rename targets (e.g. `ellipsis.sub`) are excluded from stripping so the inherited `vert` / `vrt2` mappings copied by `_copy_single_substitutions_for_features` keep working. CID cmap remap (`zero → cid00017`) and same-name `.lat` collision renames are *not* preserved — those are exactly the bug cases.
- The 65535-glyph budget fallback path now also runs the strip via a new `lat_glyph_names_override` parameter and `append_lat_lookups=False`, derived from the post-prune `all_lat_glyphs`. Previously this path passed `lat_font=None` and so left all base-side Latin-input rules untouched, leaking digits to `cid63153..cid63162` on full NotoSansCJKjp.
- Architecture docs (EN + JA) document the new strip, the narrow `.sub`-only preservation, and the budget-path coverage.

## Test plan

- [x] `pytest python/tests/` — 394 passed, 1 skipped (excluding the slow full-OTF budget regression which is class-scoped and runs only when the unsubsetted Noto Sans CJK JP fixture is present)
- [x] `pytest python/tests/test_glyph_data.py::TestCidBudgetPathDigitNoLeak` — full Noto Sans CJK JP + Inter merge confirms digits don't leak `cid63153..cid63162` (default and `tnum=1`)
- [x] `npm run build`
- [x] New regression coverage:
  - `TestLatinSingleSubstPreservation` (Inter + Noto Sans JP TTF subset, TikTok Sans + Noto Sans JP) — feature parametrize over `default` / `locl` / `tnum` / `fwid` / `hwid` / `aalt`, plus structural assertion that no base mixed Type 1/3 subtable maps `zero..nine` to base-font outputs and that Inter's `tnum` actually reaches its tabular figures (modulo `.lat` rename suffix)
  - `TestCidBaseDigitNoLeak` (Inter CFF + NotoSansCJKjp subset) — pins the CID-name regression that semantic-named subset tests miss; structural check that no base subtable keeps `cid00017..cid00026` as a source key
  - `TestCidBudgetPathDigitNoLeak` (full unsubsetted NotoSansCJKjp) — pins the budget fallback path
  - Existing `TestSharedGlyphCollateral::test_renamed_replacements_preserve_vertical_substitution` confirms the `.sub` preservation invariant still holds

🤖 Generated with [Claude Code](https://claude.com/claude-code)