### PR TITLE
Expose Latin user features from CJK script LangSys

### DIFF
--- a/docs/ARCHITECTURE.ja.md
+++ b/docs/ARCHITECTURE.ja.md
@@ -362,6 +362,80 @@ Latin script の LangSys を持たない場合（例: Latin サブが Greek 非�
 なのに base に grek LangSys がある場合）、JP 側 `ccmp` はそのまま残る
 — shadowing する相手がいないため。
 
+### CJK script から到達可能にする Latin ユーザー機能
+
+Adobe Illustrator などのアプリは、Latin と CJK が混在するランを `latn`
+の Latin ランに分割せず、`kana` / `hani` の LangSys 配下でまとめて
+shaping することがある（分割の挙動は composer・言語属性・スタイルラン・
+ドキュメントデフォルト・font cache 状態で変わる）。CJK LangSys 配下で
+shaping すると、その LangSys が参照する feature しか使えなくなるため、
+ユーザーが `ss02` / `tnum` 等を ON にしても、ランに日本語が 1 文字でも
+入った瞬間に Latin glyph 側で何も起きなくなる。
+
+`CJK_LATIN_USER_FEATURE_ALLOWLIST` は明示的な Latin ユーザー機能
+（`ss01..ss20`, `cv01..cv99`, `salt`, `zero`, `tnum`, `pnum`, `frac`,
+`numr`, `dnom`, `sups`, `subs`, `sinf`, `ordn`）に絞ったホワイトリスト
+で、Latin 側が定義しているこれらの feature を CJK script の LangSys
+からも到達可能にする。default-on / 文脈依存の Latin タグ（`aalt`,
+`locl`, `ccmp`, `liga`, `dlig`, `calt`, `case`）と CJK 固有の意味を
+持つタグ（`fwid`, `hwid`, `vert`, `vrt2`, GPOS のデフォルト群）は
+意図的に除外している — これらを CJK script 配下にぶら下げると、
+ユーザーが頼んでいないテキスト書き換えが発生し得るため。
+
+候補集合は **Latin font 自身が `latn` / `DFLT` DefaultLangSys に
+持っている** feature に限定する。Latin の FeatureList を全件舐めると
+孤立 feature や named LangSys 専用 feature（例: `latn/TUR ` 専用
+`tnum`）まで拾ってしまい、ロケール固有の挙動を `kana/dflt` 経由で
+全 Japanese ランに露出させてしまうため。生き残った候補はさらに
+`_latin_feature_safe_for_cjk_promotion` で各 lookup を再帰的に walk
+し（Context / ChainContext の `SubstLookupRecord` が指す subordinate
+lookup まで含めて）、入力 glyph 集合が `lat_glyph_names` に収まらない
+feature は除外する。多層防御: 将来の Latin source が「上位 coverage は
+Latin だが subordinate lookup が JP glyph を書き換える」chain context
+lookup を出してきても、`tnum=1` で日本語が書き換わらないようにする。
+
+**Budget path の制限**: 65535 glyph フォールバック経路
+（`merge_fonts.merge_fonts` 内の `merge_feature_tables(None, ...)`）
+では Latin glyph がドロップされるため Latin lookup を append できず、
+そもそも Latin user feature が `latn` / CJK 両方で使えない。promotion
+を有効化するには lookup pruning + chain context reference remap +
+feature/LangSys cleanup が必要で、初期 CJK promotion 修正とは別の
+PR で対応するのが安全と判断した。Subset CID merge
+（`NotoSansCJKjp-subset.otf`）は budget に収まるので promotion
+が効く。
+
+事前計算は `_merge_ot_table_v2` 内で 1 度だけ行い、
+`cjk_extra_lat_features` として `_build_lang_sys` に渡す。各 CJK
+LangSys の挙動:
+
+- allowlist タグが JP 側に存在しない場合: Latin feature record をその
+  まま追加。
+- JP 側に同タグが既に存在する場合（CJK フォントが独自に `tnum` /
+  `salt` 等を CJK glyph 用に出している等）: 同タグを 2 本ぶら下げる
+  と HarfBuzz の shadowing で片方が無視される（`ccmp` / `kern` を
+  `latn` で潰したのと同じパターン）。代わりに **JP lookup + Latin
+  lookup の合成 FeatureRecord** を新たに 1 本作って merged
+  FeatureList に追加し、当該 LangSys はそれを参照する（元の JP
+  record は触らない）。同じ `(jp_idx, lat_idx)` の組み合わせを必要
+  とする他の LangSys 用に cache する。これにより Latin の named-only
+  lookup（例: `latn/JPN ` 専用 `tnum`）が、同じ JP record を index
+  で共有している `kana/dflt` 等に leak しない。
+
+Named LangSys 対応: `cjk_extras_named[lang_tag]` には Latin
+`latn/<lang_tag>` (および `DFLT/<lang_tag>`) 固有の候補を default に
+重ねて持たせ、CJK script 側でも Latin が固有 allowlist 機能を
+持ち込む lang_tag については対応する named LangSys
+（例: `kana/JPN`）を自動生成する。両側ともその CJK script で
+当該 lang_tag を定義していなくても作る。これがないと Inter の
+`latn/JPN` 専用 `tnum` が `kana/JPN` の日本語ランから到達できない。
+
+CJK script で素の日本語を shaping したときに allowlist 機能を ON
+しても結果は変わらない — 安全チェック
+`_latin_feature_safe_for_cjk_promotion` が Context / ChainContext の
+subordinate lookup・Format 1 の SubRule.Input・Format 2 の ClassDef
+glyph キーを含めた到達可能な全 lookup を再帰的に walk し、入力 glyph
+が `lat_glyph_names` に収まらない feature を除外している。
+
 ### メトリクス
 
 - `head.unitsPerEm` = `outputUpm`（ユーザー設定、デフォルト 1000）

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -368,6 +368,87 @@ LangSys for a given explicit Latin script (e.g. `grek` when the Latin
 sub doesn't ship Greek), the JP-side `ccmp` for that script stays put
 — there's nothing to shadow it.
 
+### Latin User Features Reachable from CJK Scripts
+
+Apps such as Adobe Illustrator may shape mixed Latin/CJK runs through
+the `kana` or `hani` script's LangSys instead of splitting into a
+separate `latn` run (the split depends on composer, language attribute,
+style runs, document defaults, and font cache state). When the run is
+shaped under a CJK LangSys, only features that LangSys references are
+reachable — so toggling `ss02` / `tnum` / etc. silently no-ops on the
+Latin glyphs as soon as the run also contains a Japanese character.
+
+`CJK_LATIN_USER_FEATURE_ALLOWLIST` exposes a narrow set of explicit
+Latin user features (`ss01..ss20`, `cv01..cv99`, `salt`, `zero`,
+`tnum`, `pnum`, `frac`, `numr`, `dnom`, `sups`, `subs`, `sinf`, `ordn`)
+under CJK script LangSys records when the Latin font defines them.
+Default-on / context-sensitive Latin tags (`aalt`, `locl`, `ccmp`,
+`liga`, `dlig`, `calt`, `case`) and CJK-meaningful tags (`fwid`,
+`hwid`, `vert`, `vrt2`, GPOS defaults) are intentionally excluded —
+exposing them under CJK scripts could rewrite text the user never
+asked to change.
+
+The candidate set is restricted to features the *Latin font* exposes
+under its `latn` / `DFLT` DefaultLangSys. Iterating the full Latin
+FeatureList would also pick up orphan features and named-LangSys-only
+ones (e.g. a `latn/TUR ` Turkish-specific `tnum`), and promoting those
+to `kana/dflt` would expose locale-specific behavior across every
+Japanese run. Each surviving candidate is then passed through
+`_latin_feature_safe_for_cjk_promotion`, which transitively walks the
+feature's lookups — including subordinate lookups reached through
+Context / ChainContext `SubstLookupRecord` references — and refuses any
+whose input set reaches outside `lat_glyph_names`. This is a
+defense-in-depth check so `tnum=1` can never rewrite Japanese glyphs
+even if a future Latin source ships a chain-context lookup whose
+top-level coverage looks Latin-only but whose subordinate substitution
+hits a base glyph.
+
+**Budget path limitation.** The 65535-glyph fallback path
+(`merge_feature_tables(None, ...)` in `merge_fonts.merge_fonts`) does
+not append Latin lookups at all because the dropped Latin glyphs leave
+dangling references. Promotion is therefore unavailable on that path —
+both `latn` and CJK scripts lose Latin user features for full
+NotoSansCJKjp-class CID merges. Re-enabling it requires lookup pruning
++ chain-context reference remap + feature/LangSys cleanup with
+non-trivial regression risk; tracked as a follow-up rather than
+shipped with the initial CJK fix. Subset CID merges
+(`NotoSansCJKjp-subset.otf`) stay under budget and do get the
+promotion.
+
+The pre-computed allowlist is built once per `_merge_ot_table_v2` call
+and threaded into `_build_lang_sys` through `cjk_extra_lat_features`.
+For each CJK LangSys:
+
+- If the allowlist tag is **not** already on the JP side, the Latin
+  feature record is appended directly.
+- If the JP side already exposes the same tag (e.g. a CJK font that
+  ships its own `tnum` or `salt` for CJK glyphs), creating a second
+  feature record would let HarfBuzz shadow one of them — the same
+  pattern that bites `ccmp` / `kern` under `latn`. Instead a fresh
+  combined `FeatureRecord` (JP lookups + Latin lookups) is appended to
+  the merged FeatureList and this LangSys references the new index in
+  place of the bare JP one. The combined record is cached by
+  `(jp_idx, lat_idx)` so other LangSys that need the same combination
+  reuse it. The original JP record stays pristine, so a Latin
+  named-only lookup (e.g. `latn/JPN ` `tnum`) cannot leak into
+  `kana/dflt` even when both sides reference the same JP feature
+  record by index.
+
+Named LangSys handling: `cjk_extras_named[lang_tag]` adds candidates
+unique to Latin's `latn/<lang_tag>` (and `DFLT/<lang_tag>`) on top of
+the defaults, and CJK scripts auto-create a matching named LangSys
+(e.g. `kana/JPN `) whenever Latin contributes unique allowlist
+features for that tag — even if neither side defines that tag under
+this CJK script. Without this, an Inter `latn/JPN`-only `tnum` would
+be unreachable from any Japanese run shaped under `kana/JPN`.
+
+Plain Japanese text shaped under `kana` / `hani` stays unchanged when
+these features are toggled — the safety check
+(`_latin_feature_safe_for_cjk_promotion`) walks every reachable
+lookup, including Context / ChainContext subordinate lookups and
+Format 1 rule input sequences and Format 2 ClassDef glyph keys, and
+refuses any whose input set reaches outside `lat_glyph_names`.
+
 ### Metrics
 
 - `head.unitsPerEm` = `outputUpm` (user-set, default 1000)

--- a/python/merge_fonts.py
+++ b/python/merge_fonts.py
@@ -1460,6 +1460,40 @@ def _collect_lookup_glyphs(lookup) -> set:
                 glyph_names.update(st.mapping.keys())
             if hasattr(st, 'alternates') and st.alternates:
                 glyph_names.update(st.alternates.keys())
+            # Format 1 Context / ChainContext rule-based subtables stash
+            # the input/backtrack/lookahead sequences as raw glyph-name
+            # lists inside SubRule / ChainSubRule / PosRule / ChainPosRule
+            # records. Without this walk the safety check missed any
+            # non-Latin glyph reachable only through Format 1 rules.
+            for ruleset_attr in ('SubRuleSet', 'ChainSubRuleSet',
+                                 'PosRuleSet', 'ChainPosRuleSet'):
+                rulesets = getattr(st, ruleset_attr, None)
+                if not rulesets:
+                    continue
+                for ruleset in rulesets:
+                    if not ruleset:
+                        continue
+                    for rule_attr in ('SubRule', 'ChainSubRule',
+                                      'PosRule', 'ChainPosRule'):
+                        rules = getattr(ruleset, rule_attr, None)
+                        if not rules:
+                            continue
+                        for rule in rules:
+                            for cov_attr in ('Backtrack', 'Input',
+                                             'LookAhead'):
+                                seq = getattr(rule, cov_attr, None)
+                                if seq:
+                                    glyph_names.update(seq)
+            # Format 2 Context / ChainContext class-based subtables
+            # describe input glyphs through ClassDef.classDefs (a
+            # {glyph_name: class_id} dict). Coverage covers only the
+            # first input position; later positions live in the ClassDef
+            # tables and would otherwise be invisible.
+            for cd_attr in ('ClassDef', 'BacktrackClassDef',
+                            'InputClassDef', 'LookAheadClassDef'):
+                cd = getattr(st, cd_attr, None)
+                if cd is not None and getattr(cd, 'classDefs', None):
+                    glyph_names.update(cd.classDefs.keys())
     except Exception:
         pass  # Malformed subtable; return partial results for classification
     return glyph_names
@@ -2104,9 +2138,113 @@ CJK_SCRIPTS = {'kana', 'hani', 'hang', 'bopo', 'yi  '}
 GSUB_LATN_DEDUPE_TAGS = frozenset({'ccmp', 'dlig'})
 
 
+# Latin user-toggle GSUB features that should also be reachable from CJK
+# script LangSys records (`kana` / `hani` / ...). Apps such as Adobe
+# Illustrator may shape mixed Latin/CJK runs through a CJK script's
+# LangSys instead of splitting into a separate `latn` run; without this
+# allowlist the user's `ss02` / `tnum` toggle silently no-ops on Latin
+# glyphs whenever the run also contains a Japanese character.
+#
+# Restricted to explicit *user* features. Default-on / context-sensitive
+# tags (`aalt`, `locl`, `ccmp`, `liga`, `dlig`, `calt`, `case`) and
+# CJK-meaningful tags (`fwid`, `hwid`, `vert`, `vrt2`) are intentionally
+# excluded — exposing them under CJK scripts could rewrite text the user
+# never asked to change. See `docs/CJK_LATIN_USER_FEATURES_PLAN.md`.
+CJK_LATIN_USER_FEATURE_ALLOWLIST = frozenset(
+    {f'ss{n:02d}' for n in range(1, 21)}    # ss01..ss20
+    | {f'cv{n:02d}' for n in range(1, 100)}  # cv01..cv99
+    | {'salt', 'zero', 'tnum', 'pnum', 'frac', 'numr', 'dnom',
+       'sups', 'subs', 'sinf', 'ordn'}
+)
+
+
+def _collect_subordinate_lookup_indices(lookup) -> set:
+    """Collect every lookup index reachable from *lookup* via Context /
+    ChainContext SubstLookupRecord / PosLookupRecord, including nested
+    rule sets (Format 1/2). Does not include *lookup* itself."""
+    indices = set()
+    for subtable in lookup.SubTable:
+        st = subtable
+        if hasattr(st, 'ExtSubTable'):
+            st = st.ExtSubTable
+        if hasattr(st, 'SubstLookupRecord') and st.SubstLookupRecord:
+            for rec in st.SubstLookupRecord:
+                indices.add(rec.LookupListIndex)
+        if hasattr(st, 'PosLookupRecord') and st.PosLookupRecord:
+            for rec in st.PosLookupRecord:
+                indices.add(rec.LookupListIndex)
+        for attr in ('SubRuleSet', 'SubClassSet',
+                     'ChainSubRuleSet', 'ChainSubClassSet',
+                     'PosRuleSet', 'PosClassSet',
+                     'ChainPosRuleSet', 'ChainPosClassSet'):
+            ruleset_list = getattr(st, attr, None)
+            if not ruleset_list:
+                continue
+            for ruleset in ruleset_list:
+                if not ruleset:
+                    continue
+                for attr2 in ('SubRule', 'SubClassRule',
+                              'ChainSubRule', 'ChainSubClassRule',
+                              'PosRule', 'PosClassRule',
+                              'ChainPosRule', 'ChainPosClassRule'):
+                    rules = getattr(ruleset, attr2, None)
+                    if not rules:
+                        continue
+                    for rule in rules:
+                        if hasattr(rule, 'SubstLookupRecord') \
+                                and rule.SubstLookupRecord:
+                            for rec in rule.SubstLookupRecord:
+                                indices.add(rec.LookupListIndex)
+                        if hasattr(rule, 'PosLookupRecord') \
+                                and rule.PosLookupRecord:
+                            for rec in rule.PosLookupRecord:
+                                indices.add(rec.LookupListIndex)
+    return indices
+
+
+def _latin_feature_safe_for_cjk_promotion(feat_record, merged_lookups,
+                                          lat_glyph_names):
+    """Return True if every glyph referenced by *feat_record*'s lookups —
+    transitively, including subordinate lookups reached through Context /
+    ChainContext records — is in *lat_glyph_names*. The feature is then
+    safe to expose under a CJK script's LangSys: it can only rewrite
+    Latin-owned glyphs.
+
+    A lookup with no detectable input glyphs is treated as safe (the same
+    convention `_classify_lookup` uses for its `mixed` fallback): an empty
+    lookup is a no-op.
+    """
+    feat = feat_record.Feature
+    pending = list(feat.LookupListIndex or [])
+    visited = set()
+    while pending:
+        li = pending.pop()
+        if li in visited:
+            continue
+        visited.add(li)
+        if li < 0 or li >= len(merged_lookups):
+            return False
+        lookup = merged_lookups[li]
+        glyphs = _collect_lookup_glyphs(lookup)
+        if glyphs:
+            for g in glyphs:
+                if g not in lat_glyph_names:
+                    return False
+        # Walk Context / ChainContext subordinate lookups too: a top-level
+        # coverage that's all-Latin can still drive a subordinate lookup
+        # that touches non-Latin glyphs.
+        for sub_li in _collect_subordinate_lookup_indices(lookup):
+            if sub_li not in visited:
+                pending.append(sub_li)
+    return True
+
+
 def _build_lang_sys(jp_lang_sys, lat_lang_sys, script_tag, table_tag,
                     jp_feat_index_map, lat_feat_index_map,
-                    jp_feature_records, lat_feature_records):
+                    jp_feature_records, lat_feature_records,
+                    cjk_extra_lat_features=None,
+                    merged_feature_records=None,
+                    combined_record_cache=None):
     """Build a merged LangSys with correct feature references.
 
     Parameters:
@@ -2118,6 +2256,23 @@ def _build_lang_sys(jp_lang_sys, lat_lang_sys, script_tag, table_tag,
         lat_feat_index_map: old EN feature index -> new merged feature index
         jp_feature_records: JP FeatureList.FeatureRecord (for tag lookup)
         lat_feature_records: EN FeatureList.FeatureRecord (for tag lookup)
+        cjk_extra_lat_features: list of (tag, new_merged_idx) for allowlisted
+            Latin user features (ss02, tnum, ...). Only consulted when
+            script_tag is in CJK_SCRIPTS.
+        merged_feature_records: the merged FeatureList.FeatureRecord list
+            (jp_features + lat_features, in the same order as the merged
+            FeatureList). Required to support the duplicate-tag merge in
+            CJK_SCRIPTS: when an allowlist tag already lives on the JP
+            side of the current LangSys, a fresh combined FeatureRecord
+            (JP lookups + Latin lookups) is appended to this list and the
+            LangSys references the new index. The original JP record is
+            left untouched, so a Latin named-only lookup never leaks into
+            the JP DefaultLangSys (or any other LangSys that shares the
+            same JP record by index).
+        combined_record_cache: dict keyed by (jp_merged_idx, lat_merged_idx)
+            mapping to the cached combined FeatureRecord index. Lets every
+            LangSys that needs the same combination reuse the same
+            appended record.
     """
     from fontTools.ttLib.tables import otTables
 
@@ -2140,11 +2295,75 @@ def _build_lang_sys(jp_lang_sys, lat_lang_sys, script_tag, table_tag,
                 lat_tags_in_langsys.add(lat_feature_records[old_idx].FeatureTag)
 
     if script_tag in CJK_SCRIPTS:
-        # CJK script: use JP features only
+        # CJK script: use JP features, plus a narrow allowlist of Latin-side
+        # user features (ss02, tnum, ...) so apps that shape mixed Latin/CJK
+        # runs through a CJK LangSys can still reach them. Default-on /
+        # context-sensitive Latin tags are intentionally excluded.
+        jp_tags_in_langsys = set()
+        jp_tag_to_merged_idx = {}
         if jp_lang_sys and jp_lang_sys.FeatureIndex:
             for old_idx in jp_lang_sys.FeatureIndex:
                 if old_idx in jp_feat_index_map:
-                    feat_indices.append(jp_feat_index_map[old_idx])
+                    merged_idx = jp_feat_index_map[old_idx]
+                    feat_indices.append(merged_idx)
+                    if old_idx < len(jp_feature_records):
+                        tag = jp_feature_records[old_idx].FeatureTag
+                        jp_tags_in_langsys.add(tag)
+                        jp_tag_to_merged_idx.setdefault(tag, merged_idx)
+        # Latin user features live under Latin's `latn`/`DFLT` LangSys, not
+        # the (typically nonexistent) Latin `kana`/`hani` LangSys, so iterate
+        # the pre-computed list collected in `_merge_ot_table_v2` rather than
+        # `lat_lang_sys` (which is None for CJK script tags).
+        if table_tag == 'GSUB' and cjk_extra_lat_features:
+            for tag, new_idx in cjk_extra_lat_features:
+                if tag not in jp_tags_in_langsys:
+                    feat_indices.append(new_idx)
+                    continue
+                # Duplicate tag: HarfBuzz would only fire one of two
+                # `tnum` records (the shadowing pattern that bites
+                # GSUB_LATN_DEDUPE_TAGS under `latn`). Instead of
+                # dropping the Latin promotion *or* mutating the shared
+                # JP record (which would leak the Latin lookups into
+                # every LangSys that references the same JP record by
+                # index — for example a Latin named-only `tnum`
+                # leaking into `kana/dflt`), build a fresh combined
+                # FeatureRecord (JP lookups + Latin lookups), cache it
+                # by `(jp_idx, lat_idx)` so other LangSys reuse it, and
+                # have this LangSys reference the combined index in
+                # place of the bare JP one.
+                if (merged_feature_records is None
+                        or combined_record_cache is None):
+                    continue
+                jp_merged_idx = jp_tag_to_merged_idx.get(tag)
+                if jp_merged_idx is None:
+                    continue
+                if jp_merged_idx >= len(merged_feature_records):
+                    continue
+                if new_idx >= len(merged_feature_records):
+                    continue
+                cache_key = (jp_merged_idx, new_idx)
+                combined_idx = combined_record_cache.get(cache_key)
+                if combined_idx is None:
+                    jp_rec = merged_feature_records[jp_merged_idx]
+                    lat_rec = merged_feature_records[new_idx]
+                    combined_rec = copy.deepcopy(jp_rec)
+                    seen = set(combined_rec.Feature.LookupListIndex or [])
+                    for li in (lat_rec.Feature.LookupListIndex or []):
+                        if li not in seen:
+                            combined_rec.Feature.LookupListIndex.append(li)
+                            seen.add(li)
+                    combined_rec.Feature.LookupCount = len(
+                        combined_rec.Feature.LookupListIndex)
+                    combined_idx = len(merged_feature_records)
+                    merged_feature_records.append(combined_rec)
+                    combined_record_cache[cache_key] = combined_idx
+                # Replace the bare JP index in feat_indices with the
+                # combined index. (feat_indices was filled in the JP
+                # loop above; replace the first occurrence.)
+                for i, fi in enumerate(feat_indices):
+                    if fi == jp_merged_idx:
+                        feat_indices[i] = combined_idx
+                        break
     elif script_tag in LATIN_SCRIPTS:
         # Latin script: use EN features, plus JP CJK-only features
         # (some features like vert, vrt2 should still be available)
@@ -2342,6 +2561,12 @@ def _merge_ot_table_v2(lat_table, jp_table, lat_font, jp_font, merged,
     merged_feature_list.FeatureRecord = [f[1] for f in all_features]
     merged_feature_list.FeatureCount = len(all_features)
 
+    # Cache for per-LangSys CJK duplicate-tag combined records, keyed by
+    # (jp_merged_idx, lat_merged_idx). Same combination across LangSys
+    # reuses the same appended FeatureRecord rather than producing a new
+    # one each time.
+    combined_record_cache = {}
+
     # --- Step 4: Build merged ScriptList ---
     # Collect all script tags from both fonts
     all_script_tags = set()
@@ -2361,6 +2586,80 @@ def _merge_ot_table_v2(lat_table, jp_table, lat_font, jp_font, merged,
     jp_feature_records = jp_ot.FeatureList.FeatureRecord if jp_ot.FeatureList else []
     lat_feature_records = lat_ot.FeatureList.FeatureRecord if lat_ot.FeatureList else []
 
+    # Pre-compute allowlisted Latin user GSUB features (ss02, tnum, ...) so
+    # CJK-script LangSys records can re-expose them. Two restrictions:
+    #
+    #   1. Only features reachable from the Latin font's `latn` / `DFLT`
+    #      LangSys (default or named) are eligible. Iterating all of
+    #      `lat_feat_index_map` would also pick up orphan features that
+    #      no LangSys references at all.
+    #   2. Each candidate's lookups must only touch glyphs the Latin font
+    #      owns — including subordinate lookups reached via Context /
+    #      ChainContext records. Pan-CJK base fonts ship Latin-script
+    #      lookups too, but those live in `jp_features`, not
+    #      `lat_features`; the check still pins the invariant in case the
+    #      Latin source ever ships an allowlist tag whose lookup reaches
+    #      outside its own glyph set.
+    #
+    # Named LangSys handling: a feature only reachable through Latin's
+    # `latn/JAN` (and missing from the default) should still be reachable
+    # through CJK `kana/JAN` — Issue #12-style locale fallback.
+    # `cjk_extras_default` is the union of Latin `latn` / `DFLT` defaults
+    # (used by every CJK DefaultLangSys), and `cjk_extras_named[lang_tag]`
+    # adds the union of `latn/<lang_tag>` and `DFLT/<lang_tag>` named
+    # LangSys candidates on top of the defaults (used by every CJK named
+    # LangSys with that tag).
+    def _collect_lat_user_candidates(feat_indices, seen_tags):
+        out = []
+        for old_idx in feat_indices or []:
+            if old_idx not in lat_feat_index_map:
+                continue
+            if old_idx >= len(lat_feature_records):
+                continue
+            tag = lat_feature_records[old_idx].FeatureTag
+            if tag not in CJK_LATIN_USER_FEATURE_ALLOWLIST:
+                continue
+            # Per OpenType spec a LangSys has at most one FeatureRecord
+            # per tag, so winner-takes-all on the first occurrence is
+            # safe. If a malformed Latin source ever ships multiple
+            # `tnum` records under the same LangSys, the first wins and
+            # later duplicates are skipped here (matches HarfBuzz's
+            # behaviour for the same shape).
+            if tag in seen_tags:
+                continue
+            new_merged_idx = lat_feat_index_map[old_idx]
+            merged_feat = all_features[new_merged_idx][1]
+            if not _latin_feature_safe_for_cjk_promotion(
+                    merged_feat, merged_lookups, lat_glyph_names):
+                continue
+            seen_tags.add(tag)
+            out.append((tag, new_merged_idx))
+        return out
+
+    cjk_extras_default = []  # [(tag, new_merged_idx)]
+    cjk_extras_named = {}    # lang_tag -> [(tag, new_merged_idx)]
+    if table_tag == 'GSUB' and lat_ot.ScriptList:
+        default_seen = set()
+        for sr in lat_ot.ScriptList.ScriptRecord:
+            if sr.ScriptTag not in ('latn', 'DFLT'):
+                continue
+            ds = sr.Script.DefaultLangSys
+            if ds:
+                cjk_extras_default.extend(
+                    _collect_lat_user_candidates(ds.FeatureIndex, default_seen))
+        for sr in lat_ot.ScriptList.ScriptRecord:
+            if sr.ScriptTag not in ('latn', 'DFLT'):
+                continue
+            for lsr in (sr.Script.LangSysRecord or []):
+                tag_key = lsr.LangSysTag
+                merged_extras = cjk_extras_named.get(tag_key)
+                if merged_extras is None:
+                    merged_extras = list(cjk_extras_default)
+                    cjk_extras_named[tag_key] = merged_extras
+                seen = {t for t, _ in merged_extras}
+                merged_extras.extend(
+                    _collect_lat_user_candidates(lsr.LangSys.FeatureIndex, seen))
+
     # Build merged script records
     merged_script_records = []
     for script_tag in sorted(all_script_tags):
@@ -2377,7 +2676,10 @@ def _merge_ot_table_v2(lat_table, jp_table, lat_font, jp_font, merged,
         new_sr.Script.DefaultLangSys = _build_lang_sys(
             jp_default, lat_default, script_tag, table_tag,
             jp_feat_index_map, lat_feat_index_map,
-            jp_feature_records, lat_feature_records)
+            jp_feature_records, lat_feature_records,
+            cjk_extra_lat_features=cjk_extras_default,
+            merged_feature_records=merged_feature_list.FeatureRecord,
+            combined_record_cache=combined_record_cache)
 
         # Named LangSys records
         lang_sys_tags = set()
@@ -2391,6 +2693,16 @@ def _merge_ot_table_v2(lat_table, jp_table, lat_font, jp_font, merged,
             for lsr in lat_sr.Script.LangSysRecord:
                 lang_sys_tags.add(lsr.LangSysTag)
                 lat_lang_map[lsr.LangSysTag] = lsr.LangSys
+        # For CJK scripts, also create a named LangSys for any tag that
+        # Latin's matching named LangSys (e.g. `latn/JAN`) contributes
+        # allowlist features for, even if neither side defines that tag
+        # under this CJK script. Without this, an Inter `latn/JAN`-only
+        # `tnum` is unreachable from any Japanese run shaped under
+        # `kana/JAN`.
+        if script_tag in CJK_SCRIPTS and table_tag == 'GSUB':
+            for tag_key, extras in cjk_extras_named.items():
+                if extras and extras != cjk_extras_default:
+                    lang_sys_tags.add(tag_key)
 
         new_lang_records = []
         for lang_tag in sorted(lang_sys_tags):
@@ -2402,12 +2714,16 @@ def _merge_ot_table_v2(lat_table, jp_table, lat_font, jp_font, merged,
             # not shadow the missing side's default features.
             jp_lang_sys = jp_lang_map.get(lang_tag, jp_default)
             lat_lang_sys = lat_lang_map.get(lang_tag, lat_default)
+            extras = cjk_extras_named.get(lang_tag, cjk_extras_default)
             new_lsr.LangSys = _build_lang_sys(
                 jp_lang_sys,
                 lat_lang_sys,
                 script_tag, table_tag,
                 jp_feat_index_map, lat_feat_index_map,
-                jp_feature_records, lat_feature_records)
+                jp_feature_records, lat_feature_records,
+                cjk_extra_lat_features=extras,
+                merged_feature_records=merged_feature_list.FeatureRecord,
+                combined_record_cache=combined_record_cache)
             new_lang_records.append(new_lsr)
 
         new_sr.Script.LangSysRecord = new_lang_records if new_lang_records else []
@@ -2417,6 +2733,11 @@ def _merge_ot_table_v2(lat_table, jp_table, lat_font, jp_font, merged,
     merged_script_list = otTables.ScriptList()
     merged_script_list.ScriptRecord = merged_script_records
     merged_script_list.ScriptCount = len(merged_script_records)
+
+    # CJK duplicate-tag merge may have appended combined FeatureRecords
+    # to merged_feature_list.FeatureRecord; refresh the count so it
+    # matches the final list.
+    merged_feature_list.FeatureCount = len(merged_feature_list.FeatureRecord)
 
     # --- Step 5: Apply to merged font ---
     jp_ot.LookupList.Lookup = merged_lookups
@@ -4034,6 +4355,15 @@ def merge_fonts(config: dict) -> str:
             # — otherwise NotoSansCJKjp's ``cid00017 → cid63153`` (the
             # bug case from #23) survives and plain digits shape to base
             # CJK alternates.
+            #
+            # Limitation: this branch also bypasses Latin user-feature
+            # promotion (`ss02` / `tnum` / ... reachable from CJK
+            # scripts). Filtering the Latin GSUB to lookups whose
+            # post-rename inputs all survived would re-enable promotion
+            # here, but it requires lookup pruning + chain-context
+            # reference remap + feature/LangSys cleanup with non-trivial
+            # regression risk. Out of scope for the initial CJK-promotion
+            # fix; tracked as a follow-up.
             merge_feature_tables(None, jp_font, merged,
                                  lat_scale=final_lat_scale, lat_baseline=lat_baseline,
                                  append_lat_lookups=False,

--- a/python/tests/test_cjk_latin_user_features.py
+++ b/python/tests/test_cjk_latin_user_features.py
@@ -1,0 +1,1123 @@
+"""Tests for Latin user features being reachable under CJK script LangSys.
+
+Background:
+    Apps such as Adobe Illustrator may shape mixed Latin/CJK runs through the
+    `kana` or `hani` script's LangSys (rather than splitting into a separate
+    Latin run that uses `latn`). When that happens, Latin user features such
+    as `ss02` and `tnum` must remain reachable for the Latin glyphs in the run
+    — otherwise toggling `ss02` / `tnum` in the app silently does nothing for
+    text that contains any Japanese character.
+
+    See ``docs/CJK_LATIN_USER_FEATURES_PLAN.md``.
+"""
+
+import pytest
+
+from fontTools.ttLib import TTFont
+
+from conftest import EN_VAR, JP_VAR
+
+import merge_fonts as mf
+
+
+# ---------------------------------------------------------------------------
+# Shared HarfBuzz helper
+# ---------------------------------------------------------------------------
+
+def _shape(font_path, text, script, language, features=None):
+    """Return the glyph-name sequence produced by HarfBuzz for *text*."""
+    try:
+        import uharfbuzz as hb
+    except ImportError:
+        pytest.skip("uharfbuzz not installed")
+    with open(font_path, "rb") as f:
+        data = f.read()
+    face = hb.Face(data)
+    font = hb.Font(face)
+    order = TTFont(font_path).getGlyphOrder()
+    buf = hb.Buffer()
+    buf.add_str(text)
+    buf.script = script
+    buf.language = language
+    buf.guess_segment_properties()
+    hb.shape(font, buf, features or {})
+    return [order[g.codepoint] for g in buf.glyph_infos]
+
+
+@pytest.fixture(scope="module")
+def merged_inter_path(tmp_path_factory):
+    """Merge Inter (Latin) onto Noto Sans JP (TTF) once for the whole module."""
+    out = tmp_path_factory.mktemp("cjk_latin_features") / "merged.ttf"
+    config = {
+        "subFont": {
+            "path": EN_VAR,
+            "scale": 1.0,
+            "baselineOffset": 0,
+            "axes": [
+                {"tag": "opsz", "currentValue": 14},
+                {"tag": "wght", "currentValue": 400},
+            ],
+        },
+        "baseFont": {
+            "path": JP_VAR,
+            "scale": 1.0,
+            "baselineOffset": 0,
+            "axes": [{"tag": "wght", "currentValue": 400}],
+        },
+        "output": {"familyName": "TestCjkLatinFeatures"},
+        "export": {"path": {"font": str(out)}},
+    }
+    mf.merge_fonts(config)
+    return str(out)
+
+
+# Note: a behavioural CID-base promotion test (Latin features actually
+# firing on a CID-keyed base such as NotoSansCJKjp) is intentionally
+# missing. The Inter CFF subset shipped under `python/tests/fonts` has
+# its GSUB stripped, so it has no allowlisted features to promote;
+# pairing the full Inter CFF or Inter Variable with the CID NotoSansCJKjp
+# subset triggers a fontTools CID-compile error unrelated to this fix.
+# The TTF base path (`merged_inter_path`) covers the engine
+# behaviourally; the CID code path is exercised structurally by
+# `test_glyph_data.py::TestCidBaseDigitNoLeak` and the related strip
+# tests, neither of which depends on this promotion logic.
+
+
+# ---------------------------------------------------------------------------
+# Behavioral tests (HarfBuzz shaping)
+# ---------------------------------------------------------------------------
+
+class TestLatinUserFeaturesUnderCjkScripts:
+    """Latin user features (ss02, tnum, ...) must still fire for Latin glyphs
+    when the run is shaped under a CJK script's LangSys."""
+
+    SAMPLE = "Gla369"
+
+    def test_ss02_under_latn_baseline(self, merged_inter_path):
+        """Sanity: ss02=1 changes the lowercase ``l`` under ``latn``."""
+        plain = _shape(merged_inter_path, self.SAMPLE, "latn", "en")
+        with_ss02 = _shape(merged_inter_path, self.SAMPLE,
+                           "latn", "en", {"ss02": True})
+        assert plain != with_ss02, (
+            f"latn ss02=1 didn't change shaping (plain={plain})"
+        )
+
+    @pytest.mark.parametrize("script,language", [("kana", "ja"), ("hani", "ja")])
+    def test_ss02_under_cjk_matches_latn(self, merged_inter_path,
+                                         script, language):
+        """``ss02=1`` shaped under ``kana`` / ``hani`` must produce the same
+        Latin alternates that ``latn`` produces. Pre-fix the lowercase ``l``
+        stays as ``l`` because the CJK LangSys never references Inter's
+        ``ss02`` feature record."""
+        latn = _shape(merged_inter_path, self.SAMPLE, "latn", "en",
+                      {"ss02": True})
+        cjk = _shape(merged_inter_path, self.SAMPLE, script, language,
+                     {"ss02": True})
+        assert cjk == latn, (
+            f"{script}/{language} ss02=1 differs from latn/en: "
+            f"{script}={cjk} vs latn={latn}"
+        )
+
+    DIGITS = "012345"
+
+    @pytest.mark.parametrize("script,language", [("kana", "ja"), ("hani", "ja")])
+    def test_tnum_under_cjk_matches_latn(self, merged_inter_path,
+                                         script, language):
+        """``tnum=1`` under ``kana`` / ``hani`` must reach Inter's tabular
+        figure glyphs the same way it does under ``latn``."""
+        latn = _shape(merged_inter_path, self.DIGITS, "latn", "en",
+                      {"tnum": True})
+        cjk = _shape(merged_inter_path, self.DIGITS, script, language,
+                     {"tnum": True})
+        assert cjk == latn, (
+            f"{script}/{language} tnum=1 differs from latn/en: "
+            f"{script}={cjk} vs latn={latn}"
+        )
+
+    @pytest.mark.parametrize("script,language", [("kana", "ja"), ("hani", "ja")])
+    def test_tnum_under_cjk_changes_default(self, merged_inter_path,
+                                            script, language):
+        """Sanity: ``tnum=1`` under CJK scripts must not silently no-op."""
+        default = _shape(merged_inter_path, self.DIGITS, script, language)
+        with_tnum = _shape(merged_inter_path, self.DIGITS, script, language,
+                           {"tnum": True})
+        assert default != with_tnum, (
+            f"{script}/{language} tnum=1 silently no-op'd "
+            f"(default={default})"
+        )
+
+
+class TestCjkScriptShapingUnchangedForJapanese:
+    """Plain Japanese text shaped under CJK scripts must not be affected by
+    enabling allowlisted Latin user features. The Latin lookups only target
+    Latin glyph names, so they should never match a Japanese run.
+    """
+
+    JP_TEXT = "あいうえお北海道"
+
+    @pytest.mark.parametrize("features", [
+        None,
+        {"ss02": True},
+        {"tnum": True},
+        {"ss01": True, "ss02": True, "tnum": True, "zero": True},
+    ])
+    @pytest.mark.parametrize("script,language", [("kana", "ja"), ("hani", "ja")])
+    def test_japanese_text_unchanged(self, merged_inter_path,
+                                     script, language, features):
+        baseline = _shape(merged_inter_path, self.JP_TEXT, script, language)
+        toggled = _shape(merged_inter_path, self.JP_TEXT, script, language,
+                         features)
+        assert baseline == toggled, (
+            f"plain Japanese under {script}/{language} changed when "
+            f"toggling {features}: baseline={baseline} toggled={toggled}"
+        )
+
+
+class TestExistingCjkFeaturesStillReachable:
+    """Existing CJK features (e.g. ``fwid`` / ``hwid``) the JP base font ships
+    under ``kana`` / ``hani`` must remain reachable from those scripts after
+    the allowlist fix.
+    """
+
+    @pytest.mark.parametrize("script,language", [("kana", "ja"), ("hani", "ja")])
+    def test_fwid_feature_present_in_cjk_langsys(self, merged_inter_path,
+                                                 script, language):
+        merged = TTFont(merged_inter_path)
+        gsub = merged["GSUB"].table
+        feat_records = gsub.FeatureList.FeatureRecord
+        for sr in gsub.ScriptList.ScriptRecord:
+            if sr.ScriptTag != script or not sr.Script.DefaultLangSys:
+                continue
+            tags = {feat_records[i].FeatureTag
+                    for i in (sr.Script.DefaultLangSys.FeatureIndex or [])}
+            assert "fwid" in tags or "hwid" in tags, (
+                f"{script} DefaultLangSys lost JP-side fwid/hwid: tags={tags}"
+            )
+            return
+        pytest.fail(f"merged font has no {script} script in GSUB")
+
+
+# ---------------------------------------------------------------------------
+# Structural tests (FeatureList / LangSys shape)
+# ---------------------------------------------------------------------------
+
+class TestCjkLangSysIncludesAllowlistedLatinFeatures:
+    """``kana`` / ``hani`` LangSys records must reference allowlisted Latin
+    user features when the Latin font defines them."""
+
+    @staticmethod
+    def _cjk_default_langsys_tags(font, script_tag):
+        gsub = font["GSUB"].table
+        feat_records = gsub.FeatureList.FeatureRecord
+        for sr in gsub.ScriptList.ScriptRecord:
+            if sr.ScriptTag != script_tag or not sr.Script.DefaultLangSys:
+                continue
+            return {feat_records[i].FeatureTag
+                    for i in (sr.Script.DefaultLangSys.FeatureIndex or [])}
+        pytest.fail(f"merged font has no {script_tag} script in GSUB")
+
+    @pytest.mark.parametrize("script", ["kana", "hani"])
+    def test_kana_hani_include_inter_user_features(self, merged_inter_path,
+                                                   script):
+        """Inter ships ``ss01..ss08``, ``tnum``, ``zero``, ``frac``, ``case``,
+        ``calt``, ``locl``, etc.; the CJK LangSys must end up with the
+        allowlisted *user* features (ss01..ss08, tnum, zero, frac), but not
+        the avoided defaults (``calt``, ``case``, ``locl``)."""
+        tags = self._cjk_default_langsys_tags(TTFont(merged_inter_path), script)
+        for expected in ("ss01", "ss02", "tnum", "zero", "frac"):
+            assert expected in tags, (
+                f"{script} DefaultLangSys missing allowlisted Latin feature "
+                f"'{expected}' (tags={sorted(tags)})"
+            )
+
+
+class TestCjkLangSysExcludesAvoidedTags:
+    """The fix must not blindly copy every Latin feature into CJK LangSys
+    records. Defaults / context-sensitive features that belong to Latin's
+    own `latn` LangSys must not become reachable from CJK scripts unless
+    they were already on the JP side.
+    """
+
+    # Full avoid list from docs/CJK_LATIN_USER_FEATURES_PLAN.md. Tags the
+    # JP base already carries are exempted by the per-tag check below
+    # (preserving JP-owned `fwid` / `vert` is correct); the test only
+    # flags tags newly inherited from the Latin side.
+    AVOIDED_TAGS = (
+        "calt", "case", "ccmp", "liga", "dlig",
+        "aalt", "locl", "fwid", "hwid", "vert", "vrt2",
+    )
+
+    @staticmethod
+    def _baseline_jp_tags(font_path, script_tag):
+        """Tags the *base* font itself ships under ``script_tag`` — the merge
+        should not strip these, but the avoided-tags assertion has to ignore
+        them so we only catch *newly introduced* avoided tags from Latin."""
+        font = TTFont(font_path)
+        gsub = font["GSUB"].table
+        feat_records = gsub.FeatureList.FeatureRecord
+        for sr in gsub.ScriptList.ScriptRecord:
+            if sr.ScriptTag != script_tag or not sr.Script.DefaultLangSys:
+                continue
+            return {feat_records[i].FeatureTag
+                    for i in (sr.Script.DefaultLangSys.FeatureIndex or [])}
+        return set()
+
+    @pytest.mark.parametrize("script", ["kana", "hani"])
+    def test_no_new_avoided_tags_under_cjk(self, merged_inter_path, script):
+        merged = TTFont(merged_inter_path)
+        gsub = merged["GSUB"].table
+        feat_records = gsub.FeatureList.FeatureRecord
+        for sr in gsub.ScriptList.ScriptRecord:
+            if sr.ScriptTag != script or not sr.Script.DefaultLangSys:
+                continue
+            merged_tags = {feat_records[i].FeatureTag
+                           for i in (sr.Script.DefaultLangSys.FeatureIndex or [])}
+            jp_tags = self._baseline_jp_tags(JP_VAR, script)
+            for tag in self.AVOIDED_TAGS:
+                if tag in jp_tags:
+                    continue  # JP already had it; preserving it is correct.
+                assert tag not in merged_tags, (
+                    f"{script} DefaultLangSys gained avoided Latin tag "
+                    f"'{tag}' (full tags={sorted(merged_tags)})"
+                )
+            return
+        pytest.fail(f"merged font has no {script} script in GSUB")
+
+
+class TestCjkPromotionRespectsLatinDefaultLangSys:
+    """A Latin user feature must only become reachable from CJK scripts when
+    the *Latin font* itself exposes it in its `latn` / `DFLT` DefaultLangSys.
+    Orphan features and named-LangSys-only ones (e.g. `latn/TUR ` Turkish
+    `tnum`) must not be promoted to a cross-script default."""
+
+    @pytest.mark.parametrize("script", ["kana", "hani"])
+    def test_only_latn_default_features_promoted(self, merged_inter_path,
+                                                 script):
+        merged = TTFont(merged_inter_path)
+        gsub = merged["GSUB"].table
+        feat_records = gsub.FeatureList.FeatureRecord
+        cjk_tags = set()
+        for sr in gsub.ScriptList.ScriptRecord:
+            if sr.ScriptTag == script and sr.Script.DefaultLangSys:
+                cjk_tags = {feat_records[i].FeatureTag
+                            for i in (sr.Script.DefaultLangSys.FeatureIndex or [])}
+                break
+        else:
+            pytest.fail(f"merged font has no {script} script in GSUB")
+
+        # Inter's pre-merge `latn` / `DFLT` DefaultLangSys feature tag set.
+        inter = TTFont(EN_VAR)
+        inter_gsub = inter["GSUB"].table
+        inter_feat_records = inter_gsub.FeatureList.FeatureRecord
+        latn_default_tags = set()
+        if inter_gsub.ScriptList:
+            for sr in inter_gsub.ScriptList.ScriptRecord:
+                if sr.ScriptTag not in ("latn", "DFLT"):
+                    continue
+                ds = sr.Script.DefaultLangSys
+                if ds:
+                    latn_default_tags.update(
+                        inter_feat_records[i].FeatureTag
+                        for i in (ds.FeatureIndex or [])
+                    )
+
+        # JP base tags (we only care about *new* tags promoted from Latin).
+        jp_base = TTFont(JP_VAR)
+        jp_gsub = jp_base["GSUB"].table
+        jp_feat_records = jp_gsub.FeatureList.FeatureRecord
+        jp_tags = set()
+        for sr in jp_gsub.ScriptList.ScriptRecord:
+            if sr.ScriptTag == script and sr.Script.DefaultLangSys:
+                jp_tags = {jp_feat_records[i].FeatureTag
+                           for i in (sr.Script.DefaultLangSys.FeatureIndex or [])}
+                break
+
+        from merge_fonts import CJK_LATIN_USER_FEATURE_ALLOWLIST
+        promoted = (cjk_tags - jp_tags) & CJK_LATIN_USER_FEATURE_ALLOWLIST
+        assert promoted, (
+            f"sanity: at least one allowlisted Latin tag should be promoted "
+            f"to {script} (got cjk_tags={sorted(cjk_tags)})"
+        )
+        leaked = promoted - latn_default_tags
+        assert not leaked, (
+            f"{script} DefaultLangSys promoted tags {sorted(leaked)} that "
+            f"the Latin font doesn't expose under latn/DFLT default "
+            f"(latn_default_tags={sorted(latn_default_tags)})"
+        )
+
+
+class TestCjkPromotedLookupsTouchOnlyLatinGlyphs:
+    """Each promoted Latin user feature's lookups must only touch glyphs the
+    Latin font owns. Otherwise a `tnum=1` toggle could rewrite Japanese
+    glyphs the user never asked to change."""
+
+    @pytest.mark.parametrize("script", ["kana", "hani"])
+    def test_promoted_feature_lookups_are_latin_only(self, merged_inter_path,
+                                                     script):
+        merged = TTFont(merged_inter_path)
+        gsub = merged["GSUB"].table
+        feat_records = gsub.FeatureList.FeatureRecord
+        lookup_list = gsub.LookupList.Lookup
+
+        cjk_default = None
+        for sr in gsub.ScriptList.ScriptRecord:
+            if sr.ScriptTag == script and sr.Script.DefaultLangSys:
+                cjk_default = sr.Script.DefaultLangSys
+                break
+        assert cjk_default is not None, f"no {script} DefaultLangSys"
+
+        # Identify Latin-promoted tags: allowlisted, in CJK LangSys, but NOT
+        # in the JP base font's same LangSys.
+        from merge_fonts import (
+            CJK_LATIN_USER_FEATURE_ALLOWLIST, _collect_lookup_glyphs,
+        )
+        jp_base = TTFont(JP_VAR)
+        jp_gsub = jp_base["GSUB"].table
+        jp_feat_records = jp_gsub.FeatureList.FeatureRecord
+        jp_tags = set()
+        for sr in jp_gsub.ScriptList.ScriptRecord:
+            if sr.ScriptTag == script and sr.Script.DefaultLangSys:
+                jp_tags = {jp_feat_records[i].FeatureTag
+                           for i in (sr.Script.DefaultLangSys.FeatureIndex or [])}
+                break
+
+        # Conservative Latin-glyph-name superset: Inter's pre-merge glyphs
+        # plus the merged font's `.lat` / `.subN` rename suffixes that the
+        # merge engine introduces on collision.
+        inter_glyphs = set(TTFont(EN_VAR).getGlyphOrder())
+        merged_glyph_set = set(merged.getGlyphOrder())
+        lat_owned = {
+            g for g in merged_glyph_set
+            if g in inter_glyphs
+            or g.endswith(".lat")
+            or g.rsplit(".", 1)[0] in inter_glyphs
+        }
+
+        offending = []
+        promoted_count = 0
+        for fi in (cjk_default.FeatureIndex or []):
+            tag = feat_records[fi].FeatureTag
+            if tag in jp_tags:
+                continue
+            if tag not in CJK_LATIN_USER_FEATURE_ALLOWLIST:
+                continue
+            promoted_count += 1
+            for li in (feat_records[fi].Feature.LookupListIndex or []):
+                glyphs = _collect_lookup_glyphs(lookup_list[li])
+                bad = glyphs - lat_owned
+                if bad:
+                    offending.append((tag, li, sorted(bad)[:5]))
+
+        assert promoted_count > 0, (
+            f"sanity: expected at least one promoted Latin feature in {script}"
+        )
+        assert not offending, (
+            f"{script} promoted Latin features touch non-Latin glyphs: "
+            f"{offending[:5]}"
+        )
+
+
+class TestCjkNamedLangSysPromotion:
+    """CJK named LangSys records (e.g. `kana/JAN`) should also expose the
+    allowlisted Latin user features. Pre-fix the promotion only ran on
+    the DefaultLangSys, so an Illustrator run that selected a CJK named
+    LangSys (per Issue #12 fallback semantics) lost `ss02` / `tnum`."""
+
+    @staticmethod
+    def _named_langsys(font, script_tag, lang_sys_tag):
+        gsub = font["GSUB"].table
+        for sr in gsub.ScriptList.ScriptRecord:
+            if sr.ScriptTag != script_tag:
+                continue
+            for lsr in (sr.Script.LangSysRecord or []):
+                if lsr.LangSysTag == lang_sys_tag:
+                    return lsr.LangSys
+        return None
+
+    @staticmethod
+    def _tags(gsub, lang_sys):
+        feat_records = gsub.FeatureList.FeatureRecord
+        return {feat_records[i].FeatureTag
+                for i in (lang_sys.FeatureIndex or [])}
+
+    @pytest.mark.parametrize("script,lang_sys_tag", [
+        ("kana", "JAN "),  # Noto Sans JP defines this for Japanese
+        ("hani", "JAN "),
+    ])
+    def test_named_cjk_langsys_includes_allowlisted_latin_features(
+            self, merged_inter_path, script, lang_sys_tag):
+        merged = TTFont(merged_inter_path)
+        ls = self._named_langsys(merged, script, lang_sys_tag)
+        if ls is None:
+            pytest.skip(f"merged font has no {script}/{lang_sys_tag.strip()} "
+                        "named LangSys")
+        tags = self._tags(merged["GSUB"].table, ls)
+        for expected in ("ss01", "ss02", "tnum"):
+            assert expected in tags, (
+                f"{script}/{lang_sys_tag.strip()} missing allowlisted "
+                f"Latin feature '{expected}' (tags={sorted(tags)})"
+            )
+
+
+class TestLatinOnlyNamedLangSysPropagatesToCjk:
+    """A named LangSys that only the Latin font defines (and that exposes
+    a unique allowlist tag missing from `latn/dflt`) must still result in
+    a matching CJK named LangSys carrying the promoted feature.
+
+    None of the bundled Latin fixtures have such a LangSys (Inter has
+    only `latn/dflt`, TikTok Sans's named LangSys are subsets of its
+    default), so the test mutates Inter in memory: it carves a fake
+    `latn/JPN ` LangSys whose only feature is `tnum`, removes `tnum`
+    from `latn/dflt`, writes the modified font to disk, runs the merge,
+    and asserts that `kana/JPN ` and `hani/JPN ` exist in the merged
+    font with `tnum` reachable.
+    """
+
+    @staticmethod
+    def _patch_latin_with_named_only_tnum(src_path, dst_path):
+        """Copy *src_path* and rewrite its GSUB so `tnum` lives only
+        under a new `latn/JPN ` LangSys (removing it from every other
+        DefaultLangSys, including `DFLT`, so the candidate-collection
+        scope test is meaningful)."""
+        font = TTFont(src_path)
+        gsub = font["GSUB"].table
+        feat_records = gsub.FeatureList.FeatureRecord
+        tnum_old_idx = None
+        for i, fr in enumerate(feat_records):
+            if fr.FeatureTag == "tnum":
+                tnum_old_idx = i
+                break
+        if tnum_old_idx is None:
+            pytest.skip(f"{src_path} has no tnum feature to relocate")
+
+        # Strip tnum from every script's DefaultLangSys (latn, DFLT, ...).
+        for sr in gsub.ScriptList.ScriptRecord:
+            ds = sr.Script.DefaultLangSys
+            if ds and tnum_old_idx in (ds.FeatureIndex or []):
+                ds.FeatureIndex = [i for i in ds.FeatureIndex
+                                   if i != tnum_old_idx]
+                ds.FeatureCount = len(ds.FeatureIndex)
+
+        latn_sr = None
+        for sr in gsub.ScriptList.ScriptRecord:
+            if sr.ScriptTag == "latn":
+                latn_sr = sr
+                break
+        assert latn_sr is not None, "fixture must define latn"
+
+        # Build a fresh `latn/JPN ` named LangSys whose only FeatureIndex
+        # is tnum.
+        from fontTools.ttLib.tables import otTables
+        new_ls = otTables.LangSys()
+        new_ls.LookupOrder = None
+        new_ls.ReqFeatureIndex = 0xFFFF
+        new_ls.FeatureIndex = [tnum_old_idx]
+        new_ls.FeatureCount = 1
+        new_lsr = otTables.LangSysRecord()
+        new_lsr.LangSysTag = "JPN "
+        new_lsr.LangSys = new_ls
+
+        existing = list(latn_sr.Script.LangSysRecord or [])
+        existing.append(new_lsr)
+        # LangSysRecords must remain sorted by tag for OpenType compliance.
+        existing.sort(key=lambda lsr: lsr.LangSysTag)
+        latn_sr.Script.LangSysRecord = existing
+        latn_sr.Script.LangSysCount = len(existing)
+
+        font.save(dst_path)
+
+    @pytest.fixture(scope="class")
+    def merged_latin_only_jpn_path(self, tmp_path_factory):
+        tmp = tmp_path_factory.mktemp("latin_only_jpn")
+        patched_inter = str(tmp / "InterPatched.ttf")
+        self._patch_latin_with_named_only_tnum(EN_VAR, patched_inter)
+        out = tmp / "merged.ttf"
+        config = {
+            "subFont": {
+                "path": patched_inter,
+                "scale": 1.0,
+                "baselineOffset": 0,
+                "axes": [],
+            },
+            "baseFont": {
+                "path": JP_VAR,
+                "scale": 1.0,
+                "baselineOffset": 0,
+                "axes": [{"tag": "wght", "currentValue": 400}],
+            },
+            "output": {"familyName": "TestLatinOnlyJPN"},
+            "export": {"path": {"font": str(out)}},
+        }
+        mf.merge_fonts(config)
+        return str(out)
+
+    @pytest.mark.parametrize("script", ["kana", "hani"])
+    def test_cjk_jpn_named_langsys_created_with_tnum(
+            self, merged_latin_only_jpn_path, script):
+        merged = TTFont(merged_latin_only_jpn_path)
+        gsub = merged["GSUB"].table
+        feat_records = gsub.FeatureList.FeatureRecord
+        for sr in gsub.ScriptList.ScriptRecord:
+            if sr.ScriptTag != script:
+                continue
+            for lsr in (sr.Script.LangSysRecord or []):
+                if lsr.LangSysTag != "JPN ":
+                    continue
+                tags = {feat_records[i].FeatureTag
+                        for i in (lsr.LangSys.FeatureIndex or [])}
+                assert "tnum" in tags, (
+                    f"{script}/JPN missing promoted Latin tnum "
+                    f"(tags={sorted(tags)})"
+                )
+                return
+            pytest.fail(
+                f"{script} has no JPN named LangSys (Latin-only named "
+                f"LangSys did not propagate to CJK side)"
+            )
+        pytest.fail(f"merged font has no {script} script in GSUB")
+
+
+class TestDuplicateAllowlistTagMergesLatinLookups:
+    """When the JP base already exposes an allowlist tag (e.g. `tnum`)
+    in a CJK LangSys, the Latin-side feature record must not be silently
+    dropped. Instead the Latin lookups have to merge into the existing
+    JP feature record so the user's `tnum=1` toggle reaches Latin
+    glyphs too.
+
+    Noto Sans JP doesn't ship `tnum` under `kana`/`hani`, so the test
+    patches its GSUB to add a no-op `tnum` referencing a JP-only lookup
+    before merging."""
+
+    @staticmethod
+    def _patch_jp_with_tnum_in_kana(src_path, dst_path):
+        font = TTFont(src_path)
+        gsub = font["GSUB"].table
+
+        # Find an existing JP-only single-substitution lookup we can
+        # alias as the JP-side tnum lookup (so its inputs are JP glyphs
+        # and won't accidentally rewrite Latin digits).
+        from fontTools.ttLib.tables import otTables
+        existing_lookup_count = len(gsub.LookupList.Lookup)
+        # Build a tiny JP-only lookup: maps a JP glyph to itself (no-op
+        # in effect, but real glyph references so the merge engine
+        # treats it as "japanese"-classified, not "latin").
+        gs = font.getGlyphOrder()
+        jp_glyph = next(g for g in gs if g.startswith("uni3") or g.startswith("cid"))
+        st = otTables.SingleSubst()
+        st.mapping = {jp_glyph: jp_glyph}
+        new_lookup = otTables.Lookup()
+        new_lookup.LookupType = 1
+        new_lookup.LookupFlag = 0
+        new_lookup.SubTable = [st]
+        new_lookup.SubTableCount = 1
+        gsub.LookupList.Lookup.append(new_lookup)
+        gsub.LookupList.LookupCount = len(gsub.LookupList.Lookup)
+        new_lookup_idx = existing_lookup_count
+
+        # Build a JP-side tnum feature record pointing at it.
+        feat = otTables.Feature()
+        feat.FeatureParams = None
+        feat.LookupListIndex = [new_lookup_idx]
+        feat.LookupCount = 1
+        rec = otTables.FeatureRecord()
+        rec.FeatureTag = "tnum"
+        rec.Feature = feat
+        new_feat_idx = len(gsub.FeatureList.FeatureRecord)
+        gsub.FeatureList.FeatureRecord.append(rec)
+        gsub.FeatureList.FeatureCount = len(gsub.FeatureList.FeatureRecord)
+
+        # Wire it into kana / hani DefaultLangSys *and* every named
+        # LangSys those scripts ship — HarfBuzz routes Japanese text
+        # through `kana/JAN` rather than `kana/dflt`, so without patching
+        # the named LangSys too the test would silently exercise a
+        # different code path.
+        for sr in gsub.ScriptList.ScriptRecord:
+            if sr.ScriptTag not in ("kana", "hani"):
+                continue
+            for ls in [sr.Script.DefaultLangSys] + [
+                    lsr.LangSys for lsr in (sr.Script.LangSysRecord or [])]:
+                if ls is None:
+                    continue
+                ls.FeatureIndex = list(ls.FeatureIndex or []) + [new_feat_idx]
+                ls.FeatureCount = len(ls.FeatureIndex)
+
+        font.save(dst_path)
+
+    @pytest.fixture(scope="class")
+    def merged_jp_tnum_path(self, tmp_path_factory):
+        tmp = tmp_path_factory.mktemp("jp_tnum_collision")
+        patched_jp = str(tmp / "JpPatched.ttf")
+        self._patch_jp_with_tnum_in_kana(JP_VAR, patched_jp)
+        out = tmp / "merged.ttf"
+        config = {
+            "subFont": {
+                "path": EN_VAR,
+                "scale": 1.0,
+                "baselineOffset": 0,
+                "axes": [
+                    {"tag": "opsz", "currentValue": 14},
+                    {"tag": "wght", "currentValue": 400},
+                ],
+            },
+            "baseFont": {
+                "path": patched_jp,
+                "scale": 1.0,
+                "baselineOffset": 0,
+                "axes": [{"tag": "wght", "currentValue": 400}],
+            },
+            "output": {"familyName": "TestJpTnumCollision"},
+            "export": {"path": {"font": str(out)}},
+        }
+        mf.merge_fonts(config)
+        return str(out)
+
+    @pytest.mark.parametrize("script,language", [("kana", "ja"), ("hani", "ja")])
+    def test_collision_tag_still_promotes_latin_lookups(
+            self, merged_jp_tnum_path, script, language):
+        """When JP already exposes `tnum` under the CJK LangSys, the
+        Latin-side `tnum` lookups must still reach Latin digits. Without
+        the merge, `kana tnum=1` would silently no-op on `012`."""
+        DIGITS = "012345"
+        latn = _shape(merged_jp_tnum_path, DIGITS, "latn", "en",
+                      {"tnum": True})
+        cjk = _shape(merged_jp_tnum_path, DIGITS, script, language,
+                     {"tnum": True})
+        assert cjk == latn, (
+            f"{script}/{language} tnum=1 didn't reach Latin tabular figures "
+            f"despite JP-side tnum collision: {script}={cjk} vs latn={latn}"
+        )
+
+
+class TestNamedOnlyLatinLookupDoesNotLeakToCjkDefault:
+    """When the JP base exposes an allowlist tag in its CJK
+    DefaultLangSys *and* the Latin font exposes the same tag only
+    through a named LangSys (e.g. `latn/JPN`), the merged
+    `kana/dflt` must keep its tnum strictly JP-only — only `kana/JPN`
+    should fire the Latin named-only lookup. A naive in-place mutation
+    of the shared JP FeatureRecord would leak the locale-specific
+    Latin lookup into every CJK default run."""
+
+    @staticmethod
+    def _patched_paths(tmp_path):
+        """Return (latin_path, jp_path) with:
+            - Latin `latn/dflt` and `DFLT/dflt` have tnum stripped;
+              tnum lives only under `latn/JPN`.
+            - JP `kana/dflt` and `hani/dflt` (and their JAN named LangSys)
+              gain a no-op JP-only `tnum` referencing a JP-glyph
+              SingleSubst.
+        """
+        from fontTools.ttLib.tables import otTables
+
+        # --- Latin patch: tnum becomes named-only (latn/JPN ) ---
+        lat = TTFont(EN_VAR)
+        gsub = lat["GSUB"].table
+        feat_records = gsub.FeatureList.FeatureRecord
+        tnum_old_idx = next(i for i, fr in enumerate(feat_records)
+                            if fr.FeatureTag == "tnum")
+        for sr in gsub.ScriptList.ScriptRecord:
+            ds = sr.Script.DefaultLangSys
+            if ds and tnum_old_idx in (ds.FeatureIndex or []):
+                ds.FeatureIndex = [i for i in ds.FeatureIndex
+                                   if i != tnum_old_idx]
+                ds.FeatureCount = len(ds.FeatureIndex)
+        latn_sr = next(sr for sr in gsub.ScriptList.ScriptRecord
+                       if sr.ScriptTag == "latn")
+        new_ls = otTables.LangSys()
+        new_ls.LookupOrder = None
+        new_ls.ReqFeatureIndex = 0xFFFF
+        new_ls.FeatureIndex = [tnum_old_idx]
+        new_ls.FeatureCount = 1
+        new_lsr = otTables.LangSysRecord()
+        new_lsr.LangSysTag = "JPN "
+        new_lsr.LangSys = new_ls
+        existing = list(latn_sr.Script.LangSysRecord or []) + [new_lsr]
+        existing.sort(key=lambda l: l.LangSysTag)
+        latn_sr.Script.LangSysRecord = existing
+        latn_sr.Script.LangSysCount = len(existing)
+        latin_path = str(tmp_path / "InterPatched.ttf")
+        lat.save(latin_path)
+
+        # --- JP patch: kana/hani gain a no-op tnum (collision tag) ---
+        jp = TTFont(JP_VAR)
+        gsub_jp = jp["GSUB"].table
+        gs = jp.getGlyphOrder()
+        jp_glyph = next(g for g in gs if g.startswith("uni3"))
+        st = otTables.SingleSubst()
+        st.mapping = {jp_glyph: jp_glyph}
+        new_lookup = otTables.Lookup()
+        new_lookup.LookupType = 1
+        new_lookup.LookupFlag = 0
+        new_lookup.SubTable = [st]
+        new_lookup.SubTableCount = 1
+        gsub_jp.LookupList.Lookup.append(new_lookup)
+        gsub_jp.LookupList.LookupCount = len(gsub_jp.LookupList.Lookup)
+        new_lookup_idx = len(gsub_jp.LookupList.Lookup) - 1
+        feat = otTables.Feature()
+        feat.FeatureParams = None
+        feat.LookupListIndex = [new_lookup_idx]
+        feat.LookupCount = 1
+        rec = otTables.FeatureRecord()
+        rec.FeatureTag = "tnum"
+        rec.Feature = feat
+        new_feat_idx = len(gsub_jp.FeatureList.FeatureRecord)
+        gsub_jp.FeatureList.FeatureRecord.append(rec)
+        gsub_jp.FeatureList.FeatureCount = len(gsub_jp.FeatureList.FeatureRecord)
+        for sr in gsub_jp.ScriptList.ScriptRecord:
+            if sr.ScriptTag not in ("kana", "hani"):
+                continue
+            for ls in [sr.Script.DefaultLangSys] + [
+                    lsr.LangSys for lsr in (sr.Script.LangSysRecord or [])]:
+                if ls is None:
+                    continue
+                ls.FeatureIndex = list(ls.FeatureIndex or []) + [new_feat_idx]
+                ls.FeatureCount = len(ls.FeatureIndex)
+        jp_path = str(tmp_path / "JpPatched.ttf")
+        jp.save(jp_path)
+
+        return latin_path, jp_path
+
+    @pytest.fixture(scope="class")
+    def merged_path(self, tmp_path_factory):
+        tmp = tmp_path_factory.mktemp("named_only_leak")
+        latin_path, jp_path = self._patched_paths(tmp)
+        out = tmp / "merged.ttf"
+        config = {
+            "subFont": {
+                "path": latin_path,
+                "scale": 1.0,
+                "baselineOffset": 0,
+                "axes": [],
+            },
+            "baseFont": {
+                "path": jp_path,
+                "scale": 1.0,
+                "baselineOffset": 0,
+                "axes": [{"tag": "wght", "currentValue": 400}],
+            },
+            "output": {"familyName": "TestNamedOnlyLeak"},
+            "export": {"path": {"font": str(out)}},
+        }
+        mf.merge_fonts(config)
+        return str(out)
+
+    @staticmethod
+    def _tnum_lookup_indices(font, script, lang_sys_tag):
+        gsub = font["GSUB"].table
+        feat_records = gsub.FeatureList.FeatureRecord
+        for sr in gsub.ScriptList.ScriptRecord:
+            if sr.ScriptTag != script:
+                continue
+            if lang_sys_tag is None:
+                ls = sr.Script.DefaultLangSys
+            else:
+                ls = None
+                for lsr in (sr.Script.LangSysRecord or []):
+                    if lsr.LangSysTag == lang_sys_tag:
+                        ls = lsr.LangSys
+                        break
+            if ls is None:
+                return None
+            for fi in (ls.FeatureIndex or []):
+                if feat_records[fi].FeatureTag == "tnum":
+                    return tuple(feat_records[fi].Feature.LookupListIndex or [])
+        return None
+
+    @pytest.mark.parametrize("script", ["kana", "hani"])
+    def test_default_tnum_does_not_inherit_named_only_latin_lookup(
+            self, merged_path, script):
+        merged = TTFont(merged_path)
+        default_lookups = self._tnum_lookup_indices(merged, script, None)
+        jpn_lookups = self._tnum_lookup_indices(merged, script, "JPN ")
+        assert default_lookups is not None, (
+            f"{script} DefaultLangSys has no tnum feature record"
+        )
+        assert jpn_lookups is not None, (
+            f"{script}/JPN named LangSys has no tnum feature record"
+        )
+        leaked = set(jpn_lookups) - set(default_lookups)
+        assert leaked, (
+            f"{script}/JPN tnum should expose Latin's named-only lookup "
+            f"that {script}/dflt does not (default={default_lookups}, "
+            f"JPN={jpn_lookups})"
+        )
+        # The strict invariant: kana/dflt's tnum lookup set must NOT
+        # include any of the Latin JPN-only lookup indices.
+        latin_only = set(jpn_lookups) - set(default_lookups)
+        assert not (set(default_lookups) & latin_only), (
+            f"{script}/dflt tnum leaked Latin named-only lookups: "
+            f"default={default_lookups}, latin-only={latin_only}"
+        )
+
+
+class TestSafetyHelperRecursesIntoSubordinateLookups:
+    """`_latin_feature_safe_for_cjk_promotion` must recurse into Context /
+    ChainContext SubstLookupRecord references — a Latin-only top-level
+    coverage that drives a subordinate lookup touching a non-Latin glyph
+    must still be rejected."""
+
+    @staticmethod
+    def _make_single_subst(input_glyph, output_glyph):
+        from fontTools.ttLib.tables import otTables
+        st = otTables.SingleSubst()
+        st.mapping = {input_glyph: output_glyph}
+        lk = otTables.Lookup()
+        lk.LookupType = 1
+        lk.LookupFlag = 0
+        lk.SubTable = [st]
+        lk.SubTableCount = 1
+        return lk
+
+    @staticmethod
+    def _make_chain_context(input_glyph, subordinate_index):
+        """Build a Format 3 ChainContextSubst whose top-level input
+        coverage is *input_glyph* and that calls a subordinate lookup at
+        *subordinate_index* on the matched position.
+        """
+        from fontTools.ttLib.tables import otTables
+
+        st = otTables.ChainContextSubst()
+        st.Format = 3
+        st.BacktrackGlyphCount = 0
+        st.BacktrackCoverage = []
+        st.LookAheadGlyphCount = 0
+        st.LookAheadCoverage = []
+
+        cov = otTables.Coverage()
+        cov.glyphs = [input_glyph]
+        st.InputGlyphCount = 1
+        st.InputCoverage = [cov]
+
+        slr = otTables.SubstLookupRecord()
+        slr.SequenceIndex = 0
+        slr.LookupListIndex = subordinate_index
+        st.SubstLookupRecord = [slr]
+        st.SubstCount = 1
+
+        lk = otTables.Lookup()
+        lk.LookupType = 6
+        lk.LookupFlag = 0
+        lk.SubTable = [st]
+        lk.SubTableCount = 1
+        return lk
+
+    @staticmethod
+    def _make_feature_record(tag, lookup_indices):
+        from fontTools.ttLib.tables import otTables
+        feat = otTables.Feature()
+        feat.FeatureParams = None
+        feat.LookupListIndex = list(lookup_indices)
+        feat.LookupCount = len(feat.LookupListIndex)
+        rec = otTables.FeatureRecord()
+        rec.FeatureTag = tag
+        rec.Feature = feat
+        return rec
+
+    def test_safe_when_subordinate_only_touches_latin(self):
+        """All-Latin chain (top-level + subordinate) → safe."""
+        sub = self._make_single_subst("a", "a.alt")
+        chain = self._make_chain_context("a", subordinate_index=0)
+        merged_lookups = [sub, chain]
+        feat_rec = self._make_feature_record("ss02", [1])
+        lat_glyph_names = {"a", "a.alt"}
+        assert mf._latin_feature_safe_for_cjk_promotion(
+            feat_rec, merged_lookups, lat_glyph_names) is True
+
+    def test_unsafe_when_subordinate_touches_non_latin_glyph(self):
+        """Top-level coverage is Latin (`a`) but the subordinate lookup
+        rewrites a JP glyph (`uni3042`). Must be rejected."""
+        sub = self._make_single_subst("uni3042", "uni3042.alt")
+        chain = self._make_chain_context("a", subordinate_index=0)
+        merged_lookups = [sub, chain]
+        feat_rec = self._make_feature_record("ss02", [1])
+        lat_glyph_names = {"a"}
+        assert mf._latin_feature_safe_for_cjk_promotion(
+            feat_rec, merged_lookups, lat_glyph_names) is False
+
+    def test_unsafe_when_top_level_is_non_latin(self):
+        sub = self._make_single_subst("a", "a.alt")
+        feat_rec = self._make_feature_record("ss02", [0])
+        lat_glyph_names = set()
+        assert mf._latin_feature_safe_for_cjk_promotion(
+            feat_rec, [sub], lat_glyph_names) is False
+
+    def test_unsafe_when_lookup_index_out_of_range(self):
+        feat_rec = self._make_feature_record("ss02", [99])
+        assert mf._latin_feature_safe_for_cjk_promotion(
+            feat_rec, [], {"a"}) is False
+
+    def test_safe_when_lookup_has_no_input_glyphs(self):
+        """Empty lookup is treated as safe (matches `_classify_lookup`)."""
+        from fontTools.ttLib.tables import otTables
+        empty = otTables.Lookup()
+        empty.LookupType = 1
+        empty.LookupFlag = 0
+        empty.SubTable = []
+        empty.SubTableCount = 0
+        feat_rec = self._make_feature_record("ss02", [0])
+        assert mf._latin_feature_safe_for_cjk_promotion(
+            feat_rec, [empty], set()) is True
+
+    @staticmethod
+    def _make_chain_subst_format1(input_seq):
+        """Build a Format 1 ChainContextSubst with raw glyph-name input
+        sequence (rather than Coverage). This is the rule-based form that
+        the original `_collect_lookup_glyphs` did not walk."""
+        from fontTools.ttLib.tables import otTables
+
+        rule = otTables.ChainSubRule()
+        rule.Backtrack = []
+        rule.BacktrackGlyphCount = 0
+        rule.Input = list(input_seq[1:])  # rule input excludes first glyph
+        rule.InputGlyphCount = len(input_seq)
+        rule.LookAhead = []
+        rule.LookAheadGlyphCount = 0
+        rule.SubstLookupRecord = []
+        rule.SubstCount = 0
+
+        ruleset = otTables.ChainSubRuleSet()
+        ruleset.ChainSubRule = [rule]
+        ruleset.ChainSubRuleCount = 1
+
+        cov = otTables.Coverage()
+        cov.glyphs = [input_seq[0]]
+
+        st = otTables.ChainContextSubst()
+        st.Format = 1
+        st.Coverage = cov
+        st.ChainSubRuleSet = [ruleset]
+        st.ChainSubRuleSetCount = 1
+
+        lk = otTables.Lookup()
+        lk.LookupType = 6
+        lk.LookupFlag = 0
+        lk.SubTable = [st]
+        lk.SubTableCount = 1
+        return lk
+
+    @staticmethod
+    def _make_chain_subst_format2(coverage_glyphs, input_classdef):
+        """Build a Format 2 ChainContextSubst with separate Coverage
+        (position-0 input) and InputClassDef (per-position class table).
+        The realistic shape: Coverage describes the first glyph's input
+        set, InputClassDef classifies that *plus* later positions —
+        sometimes including non-Latin glyphs that the existing Coverage
+        walker would miss."""
+        from fontTools.ttLib.tables import otTables
+
+        cd = otTables.ClassDef()
+        cd.classDefs = dict(input_classdef)
+
+        st = otTables.ChainContextSubst()
+        st.Format = 2
+        st.InputClassDef = cd
+        st.BacktrackClassDef = None
+        st.LookAheadClassDef = None
+        cov = otTables.Coverage()
+        cov.glyphs = list(coverage_glyphs)
+        st.Coverage = cov
+
+        lk = otTables.Lookup()
+        lk.LookupType = 6
+        lk.LookupFlag = 0
+        lk.SubTable = [st]
+        lk.SubTableCount = 1
+        return lk
+
+    def test_unsafe_when_format1_rule_input_includes_non_latin(self):
+        """Format 1 ChainSubRule input glyph references must be checked."""
+        chain = self._make_chain_subst_format1(["a", "uni3042"])
+        feat_rec = self._make_feature_record("ss02", [0])
+        assert mf._latin_feature_safe_for_cjk_promotion(
+            feat_rec, [chain], {"a"}) is False
+
+    def test_safe_when_format1_rule_input_only_latin(self):
+        chain = self._make_chain_subst_format1(["a", "b"])
+        feat_rec = self._make_feature_record("ss02", [0])
+        assert mf._latin_feature_safe_for_cjk_promotion(
+            feat_rec, [chain], {"a", "b"}) is True
+
+    def test_unsafe_when_format2_classdef_includes_non_latin(self):
+        """Format 2 ClassDef glyph keys must be checked. The Coverage is
+        all-Latin (position-0 only) so the existing Coverage walker would
+        let this through; the safety failure must come from walking
+        InputClassDef.classDefs."""
+        chain = self._make_chain_subst_format2(
+            coverage_glyphs=["a"],
+            input_classdef={"a": 1, "uni3042": 2},
+        )
+        feat_rec = self._make_feature_record("ss02", [0])
+        assert mf._latin_feature_safe_for_cjk_promotion(
+            feat_rec, [chain], {"a"}) is False
+
+
+class TestCjkLangSysNoDuplicateAllowlistTags:
+    """A CJK LangSys must never list two records with the same allowlisted
+    feature tag. If the JP font already references e.g. ``tnum``, the Latin
+    record must be skipped to avoid HarfBuzz shadowing one of them."""
+
+    @pytest.mark.parametrize("script", ["kana", "hani"])
+    def test_no_duplicate_tags_in_cjk_default_langsys(self, merged_inter_path,
+                                                      script):
+        merged = TTFont(merged_inter_path)
+        gsub = merged["GSUB"].table
+        feat_records = gsub.FeatureList.FeatureRecord
+        for sr in gsub.ScriptList.ScriptRecord:
+            if sr.ScriptTag != script or not sr.Script.DefaultLangSys:
+                continue
+            tags = [feat_records[i].FeatureTag
+                    for i in (sr.Script.DefaultLangSys.FeatureIndex or [])]
+            duplicates = {t for t in tags if tags.count(t) > 1}
+            assert not duplicates, (
+                f"{script} DefaultLangSys has duplicate feature tags: "
+                f"{sorted(duplicates)} (full list={tags})"
+            )
+            return
+        pytest.fail(f"merged font has no {script} script in GSUB")
+
+
+# ---------------------------------------------------------------------------
+# Structural tests across every CJK script in CJK_SCRIPTS
+# ---------------------------------------------------------------------------
+
+class TestPromotionAppliesToEveryCjkScript:
+    """`merge_fonts.CJK_SCRIPTS` covers `kana`, `hani`, `hang`, `bopo`,
+    and `yi  `. The promotion must apply to whichever of those the merged
+    font ships, not just `kana` / `hani`. Skip scripts that the JP base
+    font doesn't define."""
+
+    def test_every_cjk_script_in_merged_font_promotes(self, merged_inter_path):
+        from merge_fonts import CJK_SCRIPTS, CJK_LATIN_USER_FEATURE_ALLOWLIST
+        merged = TTFont(merged_inter_path)
+        gsub = merged["GSUB"].table
+        feat_records = gsub.FeatureList.FeatureRecord
+
+        # Inter's `latn` default tags ∩ allowlist
+        inter = TTFont(EN_VAR)
+        inter_gsub = inter["GSUB"].table
+        inter_feat_records = inter_gsub.FeatureList.FeatureRecord
+        latn_default = set()
+        for sr in inter_gsub.ScriptList.ScriptRecord:
+            if sr.ScriptTag not in ("latn", "DFLT"):
+                continue
+            ds = sr.Script.DefaultLangSys
+            if ds:
+                latn_default.update(
+                    inter_feat_records[i].FeatureTag
+                    for i in (ds.FeatureIndex or [])
+                )
+        latn_user = latn_default & CJK_LATIN_USER_FEATURE_ALLOWLIST
+        assert latn_user, "fixture must expose at least one allowlist tag"
+
+        observed_scripts = set()
+        for sr in gsub.ScriptList.ScriptRecord:
+            if sr.ScriptTag not in CJK_SCRIPTS or not sr.Script.DefaultLangSys:
+                continue
+            observed_scripts.add(sr.ScriptTag)
+            tags = {feat_records[i].FeatureTag
+                    for i in (sr.Script.DefaultLangSys.FeatureIndex or [])}
+            missing = latn_user - tags
+            assert not missing, (
+                f"{sr.ScriptTag} DefaultLangSys missing promoted Latin "
+                f"user features: {sorted(missing)}"
+            )
+        assert observed_scripts, "merged font has no CJK scripts at all"


### PR DESCRIPTION
## Summary

Closes #25.

Apps such as Adobe Illustrator may shape mixed Latin/CJK runs through the `kana` or `hani` script's LangSys instead of splitting into a separate `latn` run (the split depends on composer, language attribute, style runs, document defaults, and font cache state). Without this fix, toggling `ss02` / `tnum` etc. silently no-ops on Latin glyphs whenever the run also contains a Japanese character.

Reproduces the issue raised at [yamatoiizuka/gen-interface-jp#1](https://github.com/yamatoiizuka/gen-interface-jp/issues/1).

The duplicate-tag merge requested in #25 is included: when JP and Latin both expose an allowlisted tag in the same CJK LangSys, `_build_lang_sys` builds a fresh combined `FeatureRecord` (JP lookups + Latin lookups) instead of skipping the Latin promotion. The combined record is cached by `(jp_idx, lat_idx)` so other LangSys reuse it, and the original JP record is left pristine to avoid leaks across LangSys that share it. Pinned by `TestDuplicateAllowlistTagMergesLatinLookups` and `TestNamedOnlyLatinLookupDoesNotLeakToCjkDefault`.

### What changed

- **`CJK_LATIN_USER_FEATURE_ALLOWLIST`** — narrow allowlist of explicit Latin user features (`ss01..ss20`, `cv01..cv99`, `salt`, `zero`, `tnum`, `pnum`, `frac`, `numr`, `dnom`, `sups`, `subs`, `sinf`, `ordn`) re-exposed under CJK script LangSys records. Default-on / context-sensitive Latin tags (`aalt`, `locl`, `ccmp`, `liga`, `dlig`, `calt`, `case`) and CJK-meaningful tags (`fwid`, `hwid`, `vert`, `vrt2`, GPOS) are intentionally excluded.
- **Candidate scoping** — only features Latin's `latn` / `DFLT` LangSys actually exposes are eligible (default + named); orphan / locale-only features are not promoted to a cross-script default.
- **`_latin_feature_safe_for_cjk_promotion`** — recursively walks each candidate's lookups, including Context / ChainContext subordinates, Format 1 `SubRule.Input` sequences, and Format 2 `ClassDef.classDefs` glyph keys, and refuses any whose input set reaches outside `lat_glyph_names`.
- **Latin-only named LangSys** — auto-create matching CJK named LangSys (e.g. Inter `latn/JPN ` → `kana/JPN `) so a named-only Latin promotion stays reachable.
- **Duplicate-tag collisions** — when JP and Latin both expose the same allowlist tag, build a fresh combined `FeatureRecord` (cached by `(jp_idx, lat_idx)`) instead of mutating the shared JP record. Prevents Latin named-only lookups from leaking into other LangSys that reference the same JP record by index.

### Out of scope (follow-up)

- 65535-glyph budget fallback path (`merge_feature_tables(None, ...)` in full NotoSansCJKjp-class CID merges) bypasses promotion entirely. Re-enabling it requires Latin GSUB lookup pruning + chain-context reference remap + feature/LangSys cleanup with non-trivial regression risk; documented in code/architecture as a known limitation.

### Code review

Iterated with Codex through three review rounds. Findings addressed inline:

- shallow lookup walk → recursive walker via `_collect_subordinate_lookup_indices`
- `_collect_lookup_glyphs` blind to Format 1/2 + ClassDef → walker extended
- Latin-only named LangSys not propagated → auto-create matching CJK named tag
- duplicate-tag dropped Latin lookups → combined-record + cache (no mutation, no leak)

## Test plan

- [x] `python3 -m pytest python/tests/` — 438 passed, 1 skipped
- [x] `npm run build`
- [x] `python3 -m pytest python/tests/test_cjk_latin_user_features.py` — 44 new tests:
  - `TestLatinUserFeaturesUnderCjkScripts` — `ss02` / `tnum` shape under `kana` / `hani` matches `latn` (HarfBuzz)
  - `TestCjkScriptShapingUnchangedForJapanese` — plain Japanese unchanged when allowlist features toggled
  - `TestExistingCjkFeaturesStillReachable` — JP `fwid` / `hwid` survive
  - `TestCjkLangSysIncludesAllowlistedLatinFeatures` / `TestCjkLangSysExcludesAvoidedTags` / `TestCjkLangSysNoDuplicateAllowlistTags` — structural invariants
  - `TestCjkPromotionRespectsLatinDefaultLangSys` — only `latn` / `DFLT` default features promoted
  - `TestCjkPromotedLookupsTouchOnlyLatinGlyphs` — promoted lookups stay Latin-only
  - `TestCjkNamedLangSysPromotion` — `kana/JAN ` / `hani/JAN ` get the promotions
  - `TestSafetyHelperRecursesIntoSubordinateLookups` — synthetic Context / ChainContext Format 1/2 fixtures
  - `TestLatinOnlyNamedLangSysPropagatesToCjk` — in-memory Latin patch creates `latn/JPN`-only `tnum`, `kana/JPN ` is auto-created
  - `TestDuplicateAllowlistTagMergesLatinLookups` — JP-side `tnum` collision still reaches Latin tabular figures
  - `TestNamedOnlyLatinLookupDoesNotLeakToCjkDefault` — combined record stays scoped to its named LangSys
  - `TestPromotionAppliesToEveryCjkScript` — every CJK script in merged font gets promoted features
- [x] Manual reproduction signal pre-fix vs post-fix:
  ```
  pre: hb-shape ... 'Gla369' --features=ss02=1 --script=kana → l (unchanged)
  post: hb-shape ... 'Gla369' --features=ss02=1 --script=kana → l.ss02
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
