### PR TITLE
[codex] Promote safe calt under CJK LangSys

### DIFF
--- a/python/merge_fonts.py
+++ b/python/merge_fonts.py
@@ -1538,14 +1538,54 @@ def _add_coverage_domain_glyphs(glyph_names: set, coverage) -> bool:
     return False
 
 
-def _add_classdef_domain_glyphs(glyph_names: set, class_def) -> bool:
-    if class_def is None:
+def _classdef_glyphs_by_class(class_def) -> dict[int, set[str]]:
+    out = {}
+    class_defs = getattr(class_def, 'classDefs', None) or {}
+    for glyph, class_id in class_defs.items():
+        out.setdefault(class_id, set()).add(glyph)
+    return out
+
+
+def _add_class_sequence_domain(glyph_names: set, class_ids,
+                               glyphs_by_class: dict[int, set[str]]) -> bool:
+    """Return True when a class sequence cannot be proven sub-font-confined."""
+    if class_ids is None:
         return False
-    class_defs = getattr(class_def, 'classDefs', None)
-    if class_defs is None:
+
+    unknown = False
+    for class_id in class_ids:
+        if class_id == 0:
+            unknown = True
+            continue
+
+        members = glyphs_by_class.get(class_id)
+        if not members:
+            unknown = True
+            continue
+
+        glyph_names.update(members)
+
+    return unknown
+
+
+def _add_class_set_domain(glyph_names: set, class_set_index: int, rules,
+                          glyphs_by_class: dict[int, set[str]]) -> bool:
+    if not rules:
         return False
-    glyph_names.update(class_defs.keys())
+    if class_set_index == 0:
+        return True
+    members = glyphs_by_class.get(class_set_index)
+    if not members:
+        return True
+    glyph_names.update(members)
     return False
+
+
+def _context_rule_input_classes(rule):
+    input_classes = getattr(rule, 'Input', None)
+    if input_classes is not None:
+        return input_classes
+    return getattr(rule, 'Class', None)
 
 
 def _add_substitution_output_glyphs(glyph_names: set, value) -> bool:
@@ -1635,8 +1675,20 @@ def _collect_gsub_subtable_full_domain(lookup_type: int, subtable) \
                     unknown = _add_glyph_sequence(
                         glyph_names, getattr(rule, 'Input', None)) or unknown
         elif fmt == 2:
-            unknown = _add_classdef_domain_glyphs(
-                glyph_names, getattr(st, 'ClassDef', None)) or unknown
+            glyphs_by_class = _classdef_glyphs_by_class(
+                getattr(st, 'ClassDef', None))
+            for class_set_index, class_set in enumerate(
+                    getattr(st, 'SubClassSet', None) or []):
+                rules = getattr(class_set, 'SubClassRule', None) or []
+                unknown = _add_class_set_domain(
+                    glyph_names, class_set_index, rules,
+                    glyphs_by_class) or unknown
+                for rule in rules:
+                    unknown = _add_class_sequence_domain(
+                        glyph_names,
+                        _context_rule_input_classes(rule),
+                        glyphs_by_class,
+                    ) or unknown
         elif fmt != 3:
             unknown = True
 
@@ -1650,10 +1702,28 @@ def _collect_gsub_subtable_full_domain(lookup_type: int, subtable) \
                             glyph_names, getattr(rule, seq_attr, None)
                         ) or unknown
         elif fmt == 2:
-            for cd_attr in ('BacktrackClassDef', 'InputClassDef',
-                            'LookAheadClassDef'):
-                unknown = _add_classdef_domain_glyphs(
-                    glyph_names, getattr(st, cd_attr, None)) or unknown
+            backtrack_by_class = _classdef_glyphs_by_class(
+                getattr(st, 'BacktrackClassDef', None))
+            input_by_class = _classdef_glyphs_by_class(
+                getattr(st, 'InputClassDef', None))
+            lookahead_by_class = _classdef_glyphs_by_class(
+                getattr(st, 'LookAheadClassDef', None))
+            for class_set_index, class_set in enumerate(
+                    getattr(st, 'ChainSubClassSet', None) or []):
+                rules = getattr(class_set, 'ChainSubClassRule', None) or []
+                unknown = _add_class_set_domain(
+                    glyph_names, class_set_index, rules,
+                    input_by_class) or unknown
+                for rule in rules:
+                    unknown = _add_class_sequence_domain(
+                        glyph_names, getattr(rule, 'Backtrack', None),
+                        backtrack_by_class) or unknown
+                    unknown = _add_class_sequence_domain(
+                        glyph_names, getattr(rule, 'Input', None),
+                        input_by_class) or unknown
+                    unknown = _add_class_sequence_domain(
+                        glyph_names, getattr(rule, 'LookAhead', None),
+                        lookahead_by_class) or unknown
         elif fmt != 3:
             unknown = True
 

--- a/python/merge_fonts.py
+++ b/python/merge_fonts.py
@@ -30,6 +30,7 @@ import shutil
 import struct
 import subprocess
 import sys
+from typing import NamedTuple
 
 from fontTools.misc.timeTools import timestampNow
 from fontTools.ttLib import TTFont
@@ -1499,6 +1500,198 @@ def _collect_lookup_glyphs(lookup) -> set:
     return glyph_names
 
 
+class LookupGlyphDomain(NamedTuple):
+    glyphs: set[str]
+    unknown: bool = False
+
+
+def _add_glyph(glyph_names: set, glyph) -> bool:
+    if glyph is None:
+        return False
+    if isinstance(glyph, str):
+        glyph_names.add(glyph)
+        return False
+    return True
+
+
+def _add_glyph_sequence(glyph_names: set, glyphs) -> bool:
+    if glyphs is None:
+        return False
+    unknown = False
+    for glyph in glyphs:
+        unknown = _add_glyph(glyph_names, glyph) or unknown
+    return unknown
+
+
+def _add_coverage_domain_glyphs(glyph_names: set, coverage) -> bool:
+    if coverage is None:
+        return False
+    if isinstance(coverage, list):
+        unknown = False
+        for cov in coverage:
+            unknown = _add_coverage_domain_glyphs(glyph_names, cov) or unknown
+        return unknown
+    glyphs = getattr(coverage, 'glyphs', None)
+    if glyphs is None:
+        return True
+    glyph_names.update(glyphs)
+    return False
+
+
+def _add_classdef_domain_glyphs(glyph_names: set, class_def) -> bool:
+    if class_def is None:
+        return False
+    class_defs = getattr(class_def, 'classDefs', None)
+    if class_defs is None:
+        return False
+    glyph_names.update(class_defs.keys())
+    return False
+
+
+def _add_substitution_output_glyphs(glyph_names: set, value) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, str):
+        glyph_names.add(value)
+        return False
+    try:
+        return _add_glyph_sequence(glyph_names, value)
+    except TypeError:
+        return True
+
+
+def _collect_gsub_subtable_full_domain(lookup_type: int, subtable) \
+        -> LookupGlyphDomain:
+    """Collect every glyph a supported GSUB subtable can match or emit."""
+    glyph_names = set()
+    unknown = False
+    st = subtable
+
+    if hasattr(st, 'ExtSubTable'):
+        lookup_type = getattr(st, 'ExtensionLookupType', lookup_type)
+        st = st.ExtSubTable
+        if st is None:
+            return LookupGlyphDomain(glyph_names, True)
+
+    for cov_attr in ('Coverage', 'BacktrackCoverage', 'InputCoverage',
+                     'LookAheadCoverage'):
+        unknown = _add_coverage_domain_glyphs(
+            glyph_names, getattr(st, cov_attr, None)) or unknown
+
+    if lookup_type == 1:
+        mapping = getattr(st, 'mapping', None)
+        if mapping:
+            glyph_names.update(mapping.keys())
+            for out_glyph in mapping.values():
+                unknown = _add_substitution_output_glyphs(
+                    glyph_names, out_glyph) or unknown
+        unknown = _add_substitution_output_glyphs(
+            glyph_names, getattr(st, 'Substitute', None)) or unknown
+
+    elif lookup_type == 2:
+        mapping = getattr(st, 'mapping', None)
+        if mapping:
+            glyph_names.update(mapping.keys())
+            for sequence in mapping.values():
+                unknown = _add_substitution_output_glyphs(
+                    glyph_names, sequence) or unknown
+        for sequence in (getattr(st, 'Sequence', None) or []):
+            unknown = _add_substitution_output_glyphs(
+                glyph_names, getattr(sequence, 'Substitute', None)) or unknown
+
+    elif lookup_type == 3:
+        alternates = getattr(st, 'alternates', None)
+        if alternates:
+            glyph_names.update(alternates.keys())
+            for alt_set in alternates.values():
+                unknown = _add_substitution_output_glyphs(
+                    glyph_names, alt_set) or unknown
+        for alt_set in (getattr(st, 'AlternateSet', None) or []):
+            unknown = _add_substitution_output_glyphs(
+                glyph_names, getattr(alt_set, 'Alternate', None)) or unknown
+
+    elif lookup_type == 4:
+        ligatures = getattr(st, 'ligatures', None)
+        if ligatures:
+            glyph_names.update(ligatures.keys())
+            for lig_list in ligatures.values():
+                for lig in (lig_list or []):
+                    unknown = _add_glyph_sequence(
+                        glyph_names, getattr(lig, 'Component', None)) or unknown
+                    unknown = _add_glyph(
+                        glyph_names, getattr(lig, 'LigGlyph', None)) or unknown
+        for lig_set in (getattr(st, 'LigatureSet', None) or []):
+            for lig in (getattr(lig_set, 'Ligature', None) or []):
+                unknown = _add_glyph_sequence(
+                    glyph_names, getattr(lig, 'Component', None)) or unknown
+                unknown = _add_glyph(
+                    glyph_names, getattr(lig, 'LigGlyph', None)) or unknown
+
+    elif lookup_type == 5:
+        fmt = getattr(st, 'Format', None)
+        if fmt == 1:
+            for ruleset in (getattr(st, 'SubRuleSet', None) or []):
+                for rule in (getattr(ruleset, 'SubRule', None) or []):
+                    unknown = _add_glyph_sequence(
+                        glyph_names, getattr(rule, 'Input', None)) or unknown
+        elif fmt == 2:
+            unknown = _add_classdef_domain_glyphs(
+                glyph_names, getattr(st, 'ClassDef', None)) or unknown
+        elif fmt != 3:
+            unknown = True
+
+    elif lookup_type == 6:
+        fmt = getattr(st, 'Format', None)
+        if fmt == 1:
+            for ruleset in (getattr(st, 'ChainSubRuleSet', None) or []):
+                for rule in (getattr(ruleset, 'ChainSubRule', None) or []):
+                    for seq_attr in ('Backtrack', 'Input', 'LookAhead'):
+                        unknown = _add_glyph_sequence(
+                            glyph_names, getattr(rule, seq_attr, None)
+                        ) or unknown
+        elif fmt == 2:
+            for cd_attr in ('BacktrackClassDef', 'InputClassDef',
+                            'LookAheadClassDef'):
+                unknown = _add_classdef_domain_glyphs(
+                    glyph_names, getattr(st, cd_attr, None)) or unknown
+        elif fmt != 3:
+            unknown = True
+
+    elif lookup_type == 7:
+        unknown = True
+
+    elif lookup_type == 8:
+        unknown = _add_substitution_output_glyphs(
+            glyph_names, getattr(st, 'Substitute', None)) or unknown
+
+    else:
+        unknown = True
+
+    return LookupGlyphDomain(glyph_names, unknown)
+
+
+def _collect_gsub_lookup_full_domain(lookup) -> LookupGlyphDomain:
+    """Collect input, context, and output glyphs for a GSUB lookup.
+
+    Unknown or malformed subtable shapes are marked unsafe instead of being
+    treated as empty no-ops; this collector is used for default-on promotion
+    safety, not broad lookup classification.
+    """
+    glyph_names = set()
+    unknown = False
+    try:
+        lookup_type = getattr(lookup, 'LookupType', None)
+        if lookup_type is None:
+            return LookupGlyphDomain(glyph_names, True)
+        for subtable in (getattr(lookup, 'SubTable', None) or []):
+            domain = _collect_gsub_subtable_full_domain(lookup_type, subtable)
+            glyph_names.update(domain.glyphs)
+            unknown = domain.unknown or unknown
+    except Exception:
+        unknown = True
+    return LookupGlyphDomain(glyph_names, unknown)
+
+
 def _classify_lookup(lookup, lat_glyph_names: set) -> str:
     """
     Classify a Japanese font's lookup as 'latin', 'japanese', or 'mixed'.
@@ -2145,17 +2338,23 @@ GSUB_LATN_DEDUPE_TAGS = frozenset({'ccmp', 'dlig'})
 # allowlist the user's `ss02` / `tnum` toggle silently no-ops on Latin
 # glyphs whenever the run also contains a Japanese character.
 #
-# Restricted to explicit *user* features. Default-on / context-sensitive
-# tags (`aalt`, `locl`, `ccmp`, `liga`, `dlig`, `calt`, `case`) and
-# CJK-meaningful tags (`fwid`, `hwid`, `vert`, `vrt2`) are intentionally
-# excluded — exposing them under CJK scripts could rewrite text the user
-# never asked to change. See `docs/CJK_LATIN_USER_FEATURES_PLAN.md`.
+# Restricted to explicit *user* features. Most default-on /
+# context-sensitive tags (`aalt`, `locl`, `ccmp`, `liga`, `dlig`, `case`)
+# and CJK-meaningful tags (`fwid`, `hwid`, `vert`, `vrt2`) are
+# intentionally excluded — exposing them under CJK scripts could rewrite
+# text the user never asked to change. `calt` remains excluded from this
+# explicit user-feature allowlist; it is handled by the stricter
+# sub-font-confined default GSUB promotion path below.
+# See `docs/CJK_LATIN_USER_FEATURES_PLAN.md`.
 CJK_LATIN_USER_FEATURE_ALLOWLIST = frozenset(
     {f'ss{n:02d}' for n in range(1, 21)}    # ss01..ss20
     | {f'cv{n:02d}' for n in range(1, 100)}  # cv01..cv99
     | {'salt', 'zero', 'tnum', 'pnum', 'frac', 'numr', 'dnom',
        'sups', 'subs', 'sinf', 'ordn'}
 )
+
+
+CJK_LATIN_STRICT_GSUB_PROMOTION_TAGS = frozenset({'calt'})
 
 
 def _collect_subordinate_lookup_indices(lookup) -> set:
@@ -2237,6 +2436,45 @@ def _latin_feature_safe_for_cjk_promotion(feat_record, merged_lookups,
             if sub_li not in visited:
                 pending.append(sub_li)
     return True
+
+
+def _sub_feature_strictly_safe_for_cjk_default_promotion(
+        feat_record, merged_lookups, sub_owned_glyphs):
+    """Return True only when a GSUB feature is sub-font-confined.
+
+    Unlike the explicit user-feature safety helper, this checks every glyph
+    reachable from the lookup closure: inputs, backtrack/lookahead context,
+    class definitions, and substitution outputs. Unknown lookup shapes are
+    unsafe because this path exposes default-on contextual features.
+    """
+    feat = feat_record.Feature
+    pending = list(feat.LookupListIndex or [])
+    visited = set()
+    saw_glyph = False
+
+    while pending:
+        li = pending.pop()
+        if li in visited:
+            continue
+        visited.add(li)
+
+        if li < 0 or li >= len(merged_lookups):
+            return False
+
+        lookup = merged_lookups[li]
+        domain = _collect_gsub_lookup_full_domain(lookup)
+        if domain.unknown:
+            return False
+        if domain.glyphs:
+            saw_glyph = True
+            if not domain.glyphs <= sub_owned_glyphs:
+                return False
+
+        for sub_li in _collect_subordinate_lookup_indices(lookup):
+            if sub_li not in visited:
+                pending.append(sub_li)
+
+    return saw_glyph
 
 
 def _build_lang_sys(jp_lang_sys, lat_lang_sys, script_tag, table_tag,
@@ -2636,6 +2874,33 @@ def _merge_ot_table_v2(lat_table, jp_table, lat_font, jp_font, merged,
             out.append((tag, new_merged_idx))
         return out
 
+    def _collect_lat_strict_gsub_candidates(feat_indices, seen_tags):
+        out = []
+        for old_idx in feat_indices or []:
+            if old_idx not in lat_feat_index_map:
+                continue
+            if old_idx >= len(lat_feature_records):
+                continue
+            tag = lat_feature_records[old_idx].FeatureTag
+            if tag not in CJK_LATIN_STRICT_GSUB_PROMOTION_TAGS:
+                continue
+            if tag in seen_tags:
+                continue
+            new_merged_idx = lat_feat_index_map[old_idx]
+            merged_feat = all_features[new_merged_idx][1]
+            if not _sub_feature_strictly_safe_for_cjk_default_promotion(
+                    merged_feat, merged_lookups, lat_glyph_names):
+                continue
+            seen_tags.add(tag)
+            out.append((tag, new_merged_idx))
+        return out
+
+    def _collect_lat_cjk_extra_candidates(feat_indices, seen_tags):
+        out = []
+        out.extend(_collect_lat_user_candidates(feat_indices, seen_tags))
+        out.extend(_collect_lat_strict_gsub_candidates(feat_indices, seen_tags))
+        return out
+
     cjk_extras_default = []  # [(tag, new_merged_idx)]
     cjk_extras_named = {}    # lang_tag -> [(tag, new_merged_idx)]
     if table_tag == 'GSUB' and lat_ot.ScriptList:
@@ -2646,7 +2911,8 @@ def _merge_ot_table_v2(lat_table, jp_table, lat_font, jp_font, merged,
             ds = sr.Script.DefaultLangSys
             if ds:
                 cjk_extras_default.extend(
-                    _collect_lat_user_candidates(ds.FeatureIndex, default_seen))
+                    _collect_lat_cjk_extra_candidates(
+                        ds.FeatureIndex, default_seen))
         for sr in lat_ot.ScriptList.ScriptRecord:
             if sr.ScriptTag not in ('latn', 'DFLT'):
                 continue
@@ -2658,7 +2924,8 @@ def _merge_ot_table_v2(lat_table, jp_table, lat_font, jp_font, merged,
                     cjk_extras_named[tag_key] = merged_extras
                 seen = {t for t, _ in merged_extras}
                 merged_extras.extend(
-                    _collect_lat_user_candidates(lsr.LangSys.FeatureIndex, seen))
+                    _collect_lat_cjk_extra_candidates(
+                        lsr.LangSys.FeatureIndex, seen))
 
     # Build merged script records
     merged_script_records = []

--- a/python/merge_fonts.py
+++ b/python/merge_fonts.py
@@ -2564,9 +2564,11 @@ def _build_lang_sys(jp_lang_sys, lat_lang_sys, script_tag, table_tag,
         lat_feat_index_map: old EN feature index -> new merged feature index
         jp_feature_records: JP FeatureList.FeatureRecord (for tag lookup)
         lat_feature_records: EN FeatureList.FeatureRecord (for tag lookup)
-        cjk_extra_lat_features: list of (tag, new_merged_idx) for allowlisted
-            Latin user features (ss02, tnum, ...). Only consulted when
-            script_tag is in CJK_SCRIPTS.
+        cjk_extra_lat_features: list of (tag, new_merged_idx) for Latin/sub
+            features promoted into CJK LangSys records. This includes
+            allowlisted explicit user features (ss02, tnum, ...) and strict
+            sub-font-confined default GSUB features such as calt. Only
+            consulted when script_tag is in CJK_SCRIPTS.
         merged_feature_records: the merged FeatureList.FeatureRecord list
             (jp_features + lat_features, in the same order as the merged
             FeatureList). Required to support the duplicate-tag merge in
@@ -2603,10 +2605,11 @@ def _build_lang_sys(jp_lang_sys, lat_lang_sys, script_tag, table_tag,
                 lat_tags_in_langsys.add(lat_feature_records[old_idx].FeatureTag)
 
     if script_tag in CJK_SCRIPTS:
-        # CJK script: use JP features, plus a narrow allowlist of Latin-side
-        # user features (ss02, tnum, ...) so apps that shape mixed Latin/CJK
-        # runs through a CJK LangSys can still reach them. Default-on /
-        # context-sensitive Latin tags are intentionally excluded.
+        # CJK script: use JP features, plus narrow Latin-side promotions so
+        # apps that shape mixed Latin/CJK runs through a CJK LangSys can still
+        # reach them. Explicit user features use the allowlist; default-on /
+        # context-sensitive Latin tags stay excluded unless they pass the
+        # separate strict sub-font-confined policy, currently limited to calt.
         jp_tags_in_langsys = set()
         jp_tag_to_merged_idx = {}
         if jp_lang_sys and jp_lang_sys.FeatureIndex:
@@ -2894,8 +2897,9 @@ def _merge_ot_table_v2(lat_table, jp_table, lat_font, jp_font, merged,
     jp_feature_records = jp_ot.FeatureList.FeatureRecord if jp_ot.FeatureList else []
     lat_feature_records = lat_ot.FeatureList.FeatureRecord if lat_ot.FeatureList else []
 
-    # Pre-compute allowlisted Latin user GSUB features (ss02, tnum, ...) so
-    # CJK-script LangSys records can re-expose them. Two restrictions:
+    # Pre-compute Latin/sub GSUB promotions so CJK-script LangSys records can
+    # re-expose explicit user features and strict default features. Two
+    # restrictions:
     #
     #   1. Only features reachable from the Latin font's `latn` / `DFLT`
     #      LangSys (default or named) are eligible. Iterating all of

--- a/python/tests/test_cjk_latin_user_features.py
+++ b/python/tests/test_cjk_latin_user_features.py
@@ -20,6 +20,159 @@ from conftest import EN_VAR, JP_VAR
 import merge_fonts as mf
 
 
+def _coverage(*glyphs):
+    from fontTools.ttLib.tables import otTables
+    cov = otTables.Coverage()
+    cov.glyphs = list(glyphs)
+    return cov
+
+
+def _make_single_subst(input_glyph, output_glyph):
+    from fontTools.ttLib.tables import otTables
+    st = otTables.SingleSubst()
+    st.mapping = {input_glyph: output_glyph}
+    lk = otTables.Lookup()
+    lk.LookupType = 1
+    lk.LookupFlag = 0
+    lk.SubTable = [st]
+    lk.SubTableCount = 1
+    return lk
+
+
+def _make_chain_context_format3(input_glyphs, subordinate_index=None,
+                                backtrack=(), lookahead=(),
+                                sequence_index=0):
+    from fontTools.ttLib.tables import otTables
+
+    st = otTables.ChainContextSubst()
+    st.Format = 3
+    st.BacktrackCoverage = [_coverage(g) for g in backtrack]
+    st.BacktrackGlyphCount = len(st.BacktrackCoverage)
+    st.InputCoverage = [_coverage(g) for g in input_glyphs]
+    st.InputGlyphCount = len(st.InputCoverage)
+    st.LookAheadCoverage = [_coverage(g) for g in lookahead]
+    st.LookAheadGlyphCount = len(st.LookAheadCoverage)
+    if subordinate_index is None:
+        st.SubstLookupRecord = []
+    else:
+        rec = otTables.SubstLookupRecord()
+        rec.SequenceIndex = sequence_index
+        rec.LookupListIndex = subordinate_index
+        st.SubstLookupRecord = [rec]
+    st.SubstCount = len(st.SubstLookupRecord)
+
+    lk = otTables.Lookup()
+    lk.LookupType = 6
+    lk.LookupFlag = 0
+    lk.SubTable = [st]
+    lk.SubTableCount = 1
+    return lk
+
+
+def _make_feature_record(tag, lookup_indices):
+    from fontTools.ttLib.tables import otTables
+    feat = otTables.Feature()
+    feat.FeatureParams = None
+    feat.LookupListIndex = list(lookup_indices)
+    feat.LookupCount = len(feat.LookupListIndex)
+    rec = otTables.FeatureRecord()
+    rec.FeatureTag = tag
+    rec.Feature = feat
+    return rec
+
+
+def _make_langsys(feature_indices):
+    from fontTools.ttLib.tables import otTables
+    ls = otTables.LangSys()
+    ls.LookupOrder = None
+    ls.ReqFeatureIndex = 0xFFFF
+    ls.FeatureIndex = list(feature_indices)
+    ls.FeatureCount = len(ls.FeatureIndex)
+    return ls
+
+
+def _make_script_record(script_tag, default_feature_indices=(), named=None):
+    from fontTools.ttLib.tables import otTables
+    sr = otTables.ScriptRecord()
+    sr.ScriptTag = script_tag
+    sr.Script = otTables.Script()
+    sr.Script.DefaultLangSys = _make_langsys(default_feature_indices)
+    records = []
+    for tag, feature_indices in (named or {}).items():
+        lsr = otTables.LangSysRecord()
+        lsr.LangSysTag = tag
+        lsr.LangSys = _make_langsys(feature_indices)
+        records.append(lsr)
+    records.sort(key=lambda lsr: lsr.LangSysTag)
+    sr.Script.LangSysRecord = records
+    sr.Script.LangSysCount = len(records)
+    return sr
+
+
+def _make_gsub_table(lookups, feature_records, script_records):
+    from fontTools.ttLib import newTable
+    from fontTools.ttLib.tables import otTables
+
+    table = newTable("GSUB")
+    gsub = otTables.GSUB()
+    gsub.Version = 0x00010000
+    lookup_list = otTables.LookupList()
+    lookup_list.Lookup = list(lookups)
+    lookup_list.LookupCount = len(lookup_list.Lookup)
+    gsub.LookupList = lookup_list
+    feature_list = otTables.FeatureList()
+    feature_list.FeatureRecord = list(feature_records)
+    feature_list.FeatureCount = len(feature_list.FeatureRecord)
+    gsub.FeatureList = feature_list
+    script_list = otTables.ScriptList()
+    script_list.ScriptRecord = list(script_records)
+    script_list.ScriptCount = len(script_list.ScriptRecord)
+    gsub.ScriptList = script_list
+    table.table = gsub
+    return table
+
+
+def _merge_minimal_gsub(lat_lookups, lat_features, lat_scripts,
+                        jp_lookups=None, jp_features=None, jp_scripts=None,
+                        lat_glyph_names=None):
+    jp_scripts = jp_scripts or [
+        _make_script_record("kana"),
+        _make_script_record("hani"),
+    ]
+    lat_table = _make_gsub_table(lat_lookups, lat_features, lat_scripts)
+    jp_table = _make_gsub_table(
+        jp_lookups or [], jp_features or [], jp_scripts)
+    mf._merge_ot_table_v2(
+        lat_table, jp_table, None, None, {}, "GSUB",
+        lat_glyph_names or set(),
+    )
+    return jp_table.table
+
+
+def _langsys(gsub, script_tag, lang_sys_tag=None):
+    for sr in gsub.ScriptList.ScriptRecord:
+        if sr.ScriptTag != script_tag:
+            continue
+        if lang_sys_tag is None:
+            return sr.Script.DefaultLangSys
+        for lsr in (sr.Script.LangSysRecord or []):
+            if lsr.LangSysTag == lang_sys_tag:
+                return lsr.LangSys
+    return None
+
+
+def _tags_for_langsys(gsub, langsys):
+    return [gsub.FeatureList.FeatureRecord[i].FeatureTag
+            for i in (langsys.FeatureIndex or [])]
+
+
+def _feature_indices_for_tag(gsub, langsys, tag):
+    return [
+        i for i in (langsys.FeatureIndex or [])
+        if gsub.FeatureList.FeatureRecord[i].FeatureTag == tag
+    ]
+
+
 # ---------------------------------------------------------------------------
 # Shared HarfBuzz helper
 # ---------------------------------------------------------------------------
@@ -146,6 +299,26 @@ class TestLatinUserFeaturesUnderCjkScripts:
             f"(default={default})"
         )
 
+    @pytest.mark.parametrize("script,language", [("kana", "ja"), ("hani", "ja")])
+    def test_default_calt_under_cjk_matches_latn_prefix(
+            self, merged_inter_path, script, language):
+        """Default-on Inter ``calt`` must remain reachable for Latin-owned
+        glyphs inside a Japanese run shaped through a CJK script."""
+        latin_text = "(15:00)"
+        mixed_text = f"{latin_text} 日本語"
+        latn = _shape(merged_inter_path, latin_text, "latn", "en")
+        latn_without_calt = _shape(
+            merged_inter_path, latin_text, "latn", "en", {"calt": False})
+        assert latn != latn_without_calt, (
+            "fixture sanity: Inter calt should affect '(15:00)' under latn"
+        )
+
+        cjk = _shape(merged_inter_path, mixed_text, script, language)
+        assert cjk[:len(latn)] == latn, (
+            f"{script}/{language} calt differs from latn/en for the Latin "
+            f"prefix: {script}={cjk[:len(latn)]} vs latn={latn}"
+        )
+
 
 class TestCjkScriptShapingUnchangedForJapanese:
     """Plain Japanese text shaped under CJK scripts must not be affected by
@@ -221,8 +394,7 @@ class TestCjkLangSysIncludesAllowlistedLatinFeatures:
                                                    script):
         """Inter ships ``ss01..ss08``, ``tnum``, ``zero``, ``frac``, ``case``,
         ``calt``, ``locl``, etc.; the CJK LangSys must end up with the
-        allowlisted *user* features (ss01..ss08, tnum, zero, frac), but not
-        the avoided defaults (``calt``, ``case``, ``locl``)."""
+        allowlisted *user* features (ss01..ss08, tnum, zero, frac)."""
         tags = self._cjk_default_langsys_tags(TTFont(merged_inter_path), script)
         for expected in ("ss01", "ss02", "tnum", "zero", "frac"):
             assert expected in tags, (
@@ -231,11 +403,32 @@ class TestCjkLangSysIncludesAllowlistedLatinFeatures:
             )
 
 
+class TestCjkLangSysIncludesStrictSafeCalt:
+    """Strictly sub-font-confined Latin ``calt`` may be promoted to CJK
+    LangSys records even though it is not a user-feature allowlist tag."""
+
+    @pytest.mark.parametrize("script", ["kana", "hani"])
+    def test_inter_calt_promoted_under_cjk_default(self, merged_inter_path,
+                                                  script):
+        merged = TTFont(merged_inter_path)
+        gsub = merged["GSUB"].table
+        ls = _langsys(gsub, script)
+        assert ls is not None, f"merged font has no {script} DefaultLangSys"
+        tags = set(_tags_for_langsys(gsub, ls))
+        assert "calt" in tags, (
+            f"{script} DefaultLangSys missing strict Latin calt promotion "
+            f"(tags={sorted(tags)})"
+        )
+
+    def test_calt_stays_out_of_user_allowlist(self):
+        assert "calt" not in mf.CJK_LATIN_USER_FEATURE_ALLOWLIST
+
+
 class TestCjkLangSysExcludesAvoidedTags:
     """The fix must not blindly copy every Latin feature into CJK LangSys
-    records. Defaults / context-sensitive features that belong to Latin's
-    own `latn` LangSys must not become reachable from CJK scripts unless
-    they were already on the JP side.
+    records. Defaults / context-sensitive features other than strictly safe
+    ``calt`` must not become reachable from CJK scripts unless they were
+    already on the JP side.
     """
 
     # Full avoid list from docs/CJK_LATIN_USER_FEATURES_PLAN.md. Tags the
@@ -243,7 +436,7 @@ class TestCjkLangSysExcludesAvoidedTags:
     # (preserving JP-owned `fwid` / `vert` is correct); the test only
     # flags tags newly inherited from the Latin side.
     AVOIDED_TAGS = (
-        "calt", "case", "ccmp", "liga", "dlig",
+        "case", "ccmp", "liga", "dlig",
         "aalt", "locl", "fwid", "hwid", "vert", "vrt2",
     )
 
@@ -847,6 +1040,137 @@ class TestNamedOnlyLatinLookupDoesNotLeakToCjkDefault:
             f"{script}/dflt tnum leaked Latin named-only lookups: "
             f"default={default_lookups}, latin-only={latin_only}"
         )
+
+
+class TestStrictCaltSafetyHelper:
+    """The strict default-on promotion helper must check the whole GSUB
+    lookup closure, not just input coverage."""
+
+    def test_accepts_context_and_output_inside_sub_font(self):
+        sub = _make_single_subst("colon", "colon.time")
+        chain = _make_chain_context_format3(
+            ["one", "colon", "zero"], subordinate_index=0, sequence_index=1)
+        feat_rec = _make_feature_record("calt", [1])
+        sub_owned = {"one", "colon", "colon.time", "zero"}
+        assert mf._sub_feature_strictly_safe_for_cjk_default_promotion(
+            feat_rec, [sub, chain], sub_owned) is True
+
+    def test_rejects_output_outside_sub_font(self):
+        lookup = _make_single_subst("A", "uni65E5")
+        feat_rec = _make_feature_record("calt", [0])
+        assert mf._sub_feature_strictly_safe_for_cjk_default_promotion(
+            feat_rec, [lookup], {"A"}) is False
+
+    def test_rejects_lookahead_outside_sub_font(self):
+        lookup = _make_chain_context_format3(["A"], lookahead=["uni65E5"])
+        feat_rec = _make_feature_record("calt", [0])
+        assert mf._sub_feature_strictly_safe_for_cjk_default_promotion(
+            feat_rec, [lookup], {"A"}) is False
+
+    def test_rejects_unknown_lookup_shape(self):
+        from fontTools.ttLib.tables import otTables
+        st = otTables.ContextSubst()
+        st.Format = 99
+        lookup = otTables.Lookup()
+        lookup.LookupType = 5
+        lookup.LookupFlag = 0
+        lookup.SubTable = [st]
+        lookup.SubTableCount = 1
+        feat_rec = _make_feature_record("calt", [0])
+        assert mf._sub_feature_strictly_safe_for_cjk_default_promotion(
+            feat_rec, [lookup], set()) is False
+
+    def test_rejects_empty_feature(self):
+        from fontTools.ttLib.tables import otTables
+        lookup = otTables.Lookup()
+        lookup.LookupType = 1
+        lookup.LookupFlag = 0
+        lookup.SubTable = []
+        lookup.SubTableCount = 0
+        feat_rec = _make_feature_record("calt", [0])
+        assert mf._sub_feature_strictly_safe_for_cjk_default_promotion(
+            feat_rec, [lookup], set()) is False
+
+
+class TestStrictCaltPromotionStructure:
+    """Synthetic GSUB tables exercise promotion scoping without the cost of
+    compiling patched real fonts for every unsafe case."""
+
+    @staticmethod
+    def _latn_default_gsub_for_calt(lookup, lat_glyph_names):
+        return _merge_minimal_gsub(
+            [lookup],
+            [_make_feature_record("calt", [0])],
+            [_make_script_record("latn", [0])],
+            lat_glyph_names=lat_glyph_names,
+        )
+
+    @pytest.mark.parametrize("script", ["kana", "hani"])
+    def test_safe_calt_is_promoted_to_cjk_default(self, script):
+        lookup = _make_single_subst("A", "A.alt")
+        gsub = self._latn_default_gsub_for_calt(lookup, {"A", "A.alt"})
+        ls = _langsys(gsub, script)
+        assert "calt" in _tags_for_langsys(gsub, ls)
+
+    @pytest.mark.parametrize("script", ["kana", "hani"])
+    def test_unsafe_output_calt_is_not_promoted(self, script):
+        lookup = _make_single_subst("A", "uni65E5")
+        gsub = self._latn_default_gsub_for_calt(lookup, {"A"})
+        ls = _langsys(gsub, script)
+        assert "calt" not in _tags_for_langsys(gsub, ls)
+
+    @pytest.mark.parametrize("script", ["kana", "hani"])
+    def test_unsafe_lookahead_calt_is_not_promoted(self, script):
+        lookup = _make_chain_context_format3(["A"], lookahead=["uni65E5"])
+        gsub = self._latn_default_gsub_for_calt(lookup, {"A"})
+        ls = _langsys(gsub, script)
+        assert "calt" not in _tags_for_langsys(gsub, ls)
+
+    @pytest.mark.parametrize("script", ["kana", "hani"])
+    def test_duplicate_calt_tag_combines_without_mutating_jp_record(
+            self, script):
+        jp_lookup = _make_single_subst("uni65E5", "uni65E5.alt")
+        lat_lookup = _make_single_subst("A", "A.alt")
+        gsub = _merge_minimal_gsub(
+            [lat_lookup],
+            [_make_feature_record("calt", [0])],
+            [_make_script_record("latn", [0])],
+            jp_lookups=[jp_lookup],
+            jp_features=[_make_feature_record("calt", [0])],
+            jp_scripts=[
+                _make_script_record("kana", [0]),
+                _make_script_record("hani", [0]),
+            ],
+            lat_glyph_names={"A", "A.alt"},
+        )
+        ls = _langsys(gsub, script)
+        tags = _tags_for_langsys(gsub, ls)
+        assert tags.count("calt") == 1
+        [combined_idx] = _feature_indices_for_tag(gsub, ls, "calt")
+        combined_lookups = (
+            gsub.FeatureList.FeatureRecord[combined_idx]
+            .Feature.LookupListIndex
+        )
+        assert combined_lookups == [0, 1]
+        original_jp_lookups = (
+            gsub.FeatureList.FeatureRecord[0].Feature.LookupListIndex
+        )
+        assert original_jp_lookups == [0]
+
+    @pytest.mark.parametrize("script", ["kana", "hani"])
+    def test_named_only_calt_does_not_leak_to_cjk_default(self, script):
+        lookup = _make_single_subst("A", "A.alt")
+        gsub = _merge_minimal_gsub(
+            [lookup],
+            [_make_feature_record("calt", [0])],
+            [_make_script_record("latn", [], named={"JPN ": [0]})],
+            lat_glyph_names={"A", "A.alt"},
+        )
+        default_ls = _langsys(gsub, script)
+        named_ls = _langsys(gsub, script, "JPN ")
+        assert "calt" not in _tags_for_langsys(gsub, default_ls)
+        assert named_ls is not None
+        assert "calt" in _tags_for_langsys(gsub, named_ls)
 
 
 class TestSafetyHelperRecursesIntoSubordinateLookups:

--- a/python/tests/test_cjk_latin_user_features.py
+++ b/python/tests/test_cjk_latin_user_features.py
@@ -1236,6 +1236,17 @@ class TestStrictCaltSafetyHelper:
         assert mf._sub_feature_strictly_safe_for_cjk_default_promotion(
             feat_rec, [lookup], {"A", "colon", "A.alt"}) is False
 
+    def test_accepts_context_format2_nonzero_sub_owned_classes(self):
+        lookup = _make_context_subst_format2(
+            coverage_glyphs=["A"],
+            class_defs={"A": 1, "colon": 2},
+            class_set_index=1,
+            input_classes=[2],
+        )
+        feat_rec = _make_feature_record("calt", [0])
+        assert mf._sub_feature_strictly_safe_for_cjk_default_promotion(
+            feat_rec, [lookup], {"A", "colon"}) is True
+
     def test_accepts_chain_context_format2_nonzero_sub_owned_classes(self):
         sub = _make_single_subst("A", "A.alt")
         chain = _make_chain_context_format2(

--- a/python/tests/test_cjk_latin_user_features.py
+++ b/python/tests/test_cjk_latin_user_features.py
@@ -69,6 +69,103 @@ def _make_chain_context_format3(input_glyphs, subordinate_index=None,
     return lk
 
 
+def _class_def(mapping):
+    from fontTools.ttLib.tables import otTables
+    cd = otTables.ClassDef()
+    cd.classDefs = dict(mapping)
+    return cd
+
+
+def _make_sub_class_set(index, input_classes=()):
+    from fontTools.ttLib.tables import otTables
+    rule = otTables.SubClassRule()
+    rule.GlyphCount = len(input_classes) + 1
+    rule.Class = list(input_classes)
+    rule.SubstLookupRecord = []
+    rule.SubstCount = 0
+
+    class_set = otTables.SubClassSet()
+    class_set.SubClassRule = [rule]
+    class_set.SubClassRuleCount = 1
+    class_sets = [None] * (index + 1)
+    class_sets[index] = class_set
+    return class_sets
+
+
+def _make_context_subst_format2(coverage_glyphs, class_defs,
+                                class_set_index, input_classes=()):
+    from fontTools.ttLib.tables import otTables
+    st = otTables.ContextSubst()
+    st.Format = 2
+    st.Coverage = _coverage(*coverage_glyphs)
+    st.ClassDef = _class_def(class_defs)
+    st.SubClassSet = _make_sub_class_set(class_set_index, input_classes)
+    st.SubClassSetCount = len(st.SubClassSet)
+
+    lk = otTables.Lookup()
+    lk.LookupType = 5
+    lk.LookupFlag = 0
+    lk.SubTable = [st]
+    lk.SubTableCount = 1
+    return lk
+
+
+def _make_chain_sub_class_set(index, backtrack=(), input_classes=(),
+                              lookahead=(), subordinate_index=None):
+    from fontTools.ttLib.tables import otTables
+    rule = otTables.ChainSubClassRule()
+    rule.Backtrack = list(backtrack)
+    rule.BacktrackGlyphCount = len(rule.Backtrack)
+    rule.Input = list(input_classes)
+    rule.InputGlyphCount = len(rule.Input) + 1
+    rule.LookAhead = list(lookahead)
+    rule.LookAheadGlyphCount = len(rule.LookAhead)
+    if subordinate_index is None:
+        rule.SubstLookupRecord = []
+    else:
+        rec = otTables.SubstLookupRecord()
+        rec.SequenceIndex = 0
+        rec.LookupListIndex = subordinate_index
+        rule.SubstLookupRecord = [rec]
+    rule.SubstCount = len(rule.SubstLookupRecord)
+
+    class_set = otTables.ChainSubClassSet()
+    class_set.ChainSubClassRule = [rule]
+    class_set.ChainSubClassRuleCount = 1
+    class_sets = [None] * (index + 1)
+    class_sets[index] = class_set
+    return class_sets
+
+
+def _make_chain_context_format2(coverage_glyphs, input_class_defs,
+                                class_set_index, backtrack_class_defs=None,
+                                lookahead_class_defs=None, backtrack=(),
+                                input_classes=(), lookahead=(),
+                                subordinate_index=None):
+    from fontTools.ttLib.tables import otTables
+    st = otTables.ChainContextSubst()
+    st.Format = 2
+    st.Coverage = _coverage(*coverage_glyphs)
+    st.BacktrackClassDef = _class_def(backtrack_class_defs or {})
+    st.InputClassDef = _class_def(input_class_defs)
+    st.LookAheadClassDef = _class_def(lookahead_class_defs or {})
+    st.ChainSubClassSet = _make_chain_sub_class_set(
+        class_set_index,
+        backtrack=backtrack,
+        input_classes=input_classes,
+        lookahead=lookahead,
+        subordinate_index=subordinate_index,
+    )
+    st.ChainSubClassSetCount = len(st.ChainSubClassSet)
+
+    lk = otTables.Lookup()
+    lk.LookupType = 6
+    lk.LookupFlag = 0
+    lk.SubTable = [st]
+    lk.SubTableCount = 1
+    return lk
+
+
 def _make_feature_record(tag, lookup_indices):
     from fontTools.ttLib.tables import otTables
     feat = otTables.Feature()
@@ -1090,6 +1187,68 @@ class TestStrictCaltSafetyHelper:
         feat_rec = _make_feature_record("calt", [0])
         assert mf._sub_feature_strictly_safe_for_cjk_default_promotion(
             feat_rec, [lookup], set()) is False
+
+    def test_rejects_context_format2_first_input_class_zero(self):
+        lookup = _make_context_subst_format2(
+            coverage_glyphs=["A"],
+            class_defs={"A": 1},
+            class_set_index=0,
+        )
+        feat_rec = _make_feature_record("calt", [0])
+        assert mf._sub_feature_strictly_safe_for_cjk_default_promotion(
+            feat_rec, [lookup], {"A", "A.alt"}) is False
+
+    def test_rejects_context_format2_input_class_zero(self):
+        lookup = _make_context_subst_format2(
+            coverage_glyphs=["A"],
+            class_defs={"A": 1, "colon": 2},
+            class_set_index=1,
+            input_classes=[0],
+        )
+        feat_rec = _make_feature_record("calt", [0])
+        assert mf._sub_feature_strictly_safe_for_cjk_default_promotion(
+            feat_rec, [lookup], {"A", "colon", "A.alt"}) is False
+
+    def test_rejects_chain_context_format2_first_input_class_zero(self):
+        lookup = _make_chain_context_format2(
+            coverage_glyphs=["A"],
+            input_class_defs={"A": 1},
+            class_set_index=0,
+        )
+        feat_rec = _make_feature_record("calt", [0])
+        assert mf._sub_feature_strictly_safe_for_cjk_default_promotion(
+            feat_rec, [lookup], {"A", "A.alt"}) is False
+
+    @pytest.mark.parametrize("seq_name,seq_kwargs", [
+        ("backtrack", {"backtrack": [0], "backtrack_class_defs": {"colon": 2}}),
+        ("input", {"input_classes": [0]}),
+        ("lookahead", {"lookahead": [0], "lookahead_class_defs": {"colon": 2}}),
+    ])
+    def test_rejects_chain_context_format2_class_zero_sequence(
+            self, seq_name, seq_kwargs):
+        lookup = _make_chain_context_format2(
+            coverage_glyphs=["A"],
+            input_class_defs={"A": 1, "colon": 2},
+            class_set_index=1,
+            **seq_kwargs,
+        )
+        feat_rec = _make_feature_record("calt", [0])
+        assert mf._sub_feature_strictly_safe_for_cjk_default_promotion(
+            feat_rec, [lookup], {"A", "colon", "A.alt"}) is False
+
+    def test_accepts_chain_context_format2_nonzero_sub_owned_classes(self):
+        sub = _make_single_subst("A", "A.alt")
+        chain = _make_chain_context_format2(
+            coverage_glyphs=["A"],
+            input_class_defs={"A": 1},
+            class_set_index=1,
+            lookahead_class_defs={"colon": 2},
+            lookahead=[2],
+            subordinate_index=0,
+        )
+        feat_rec = _make_feature_record("calt", [1])
+        assert mf._sub_feature_strictly_safe_for_cjk_default_promotion(
+            feat_rec, [sub, chain], {"A", "A.alt", "colon"}) is True
 
 
 class TestStrictCaltPromotionStructure:


### PR DESCRIPTION
## Summary

- add a strict GSUB lookup-domain safety path for default-on Latin `calt` promotion
- expose safe Latin/sub `calt` through CJK LangSys records without adding it to `CJK_LATIN_USER_FEATURE_ALLOWLIST`
- cover safe promotion, unsafe context/output rejection, duplicate-tag merging, named-only scoping, and Inter mixed-run shaping

## Why

Fixes #29. Adobe Illustrator can shape mixed Latin/CJK text through `kana` / `hani`, which made Inter-style `calt` unreachable for Latin-owned punctuation and digits in runs such as `(15:00) 日本語`. Since `calt` is default-on and contextual, this uses a stricter sub-font-confined rule instead of the explicit user-feature allowlist.

## Validation

- `PYTHONPATH=python python3 -m pytest python/tests/test_cjk_latin_user_features.py -q -k "StrictCalt or calt_stays or calt_promoted or default_calt"` -> 20 passed, 44 deselected
- `PYTHONPATH=python python3 -m pytest python/tests/test_cjk_latin_user_features.py -q` -> 64 passed
- `PYTHONPATH=python python3 -m pytest python/tests/test_filter_subordinate_lookups.py -q` -> 7 passed
- `PYTHONPATH=python python3 -m pytest python/tests/test_glyph_data.py -q -k "calt or dlig or ccmp or subordinate or LangSys or lookup or DigitNoLeak or aalt"` -> 52 passed, 1 skipped, 148 deselected
- `PYTHONPATH=python python3 -m pytest python/tests/ -q` -> 469 passed, 1 skipped
- `npm run build` -> passed
