### PR TITLE
[codex] Broaden strict GSUB promotion

### DIFF
--- a/python/merge_fonts.py
+++ b/python/merge_fonts.py
@@ -2408,13 +2408,11 @@ GSUB_LATN_DEDUPE_TAGS = frozenset({'ccmp', 'dlig'})
 # allowlist the user's `ss02` / `tnum` toggle silently no-ops on Latin
 # glyphs whenever the run also contains a Japanese character.
 #
-# Restricted to explicit *user* features. Most default-on /
-# context-sensitive tags (`aalt`, `locl`, `ccmp`, `liga`, `dlig`, `case`)
-# and CJK-meaningful tags (`fwid`, `hwid`, `vert`, `vrt2`) are
-# intentionally excluded — exposing them under CJK scripts could rewrite
-# text the user never asked to change. `calt` remains excluded from this
-# explicit user-feature allowlist; it is handled by the stricter
-# sub-font-confined default GSUB promotion path below.
+# Restricted to explicit *user* features. Default-on, context-sensitive, or
+# semantically special GSUB tags (`calt`, `liga`, `ccmp`, `case`, `dlig`)
+# remain out of this allowlist and use the strict full-domain policy below.
+# Language/alternate/CJK-layout tags (`locl`, `aalt`, `fwid`, `hwid`, `vert`,
+# `vrt2`) remain out of scope for cross-script Latin/sub promotion.
 # See `docs/CJK_LATIN_USER_FEATURES_PLAN.md`.
 CJK_LATIN_USER_FEATURE_ALLOWLIST = frozenset(
     {f'ss{n:02d}' for n in range(1, 21)}    # ss01..ss20
@@ -2424,7 +2422,34 @@ CJK_LATIN_USER_FEATURE_ALLOWLIST = frozenset(
 )
 
 
-CJK_LATIN_STRICT_GSUB_PROMOTION_TAGS = frozenset({'calt'})
+# Latin/sub GSUB tags that may be exposed under CJK LangSys only after the
+# strict sub-font-confined full-domain check passes. This policy includes
+# default-on, context-sensitive, or semantically special tags whose inputs,
+# context, outputs, and subordinate lookup closure must all stay sub-owned.
+CJK_LATIN_STRICT_GSUB_PROMOTION_POLICIES = {
+    'calt': {
+        'kind': 'default_contextual',
+        'scope': 'default_and_named',
+    },
+    'liga': {
+        'kind': 'default_ligature',
+        'scope': 'default_and_named',
+    },
+    'ccmp': {
+        'kind': 'required_composition',
+        'scope': 'default_and_named',
+    },
+    'case': {
+        'kind': 'app_or_user_enabled',
+        'scope': 'default_and_named',
+    },
+    'dlig': {
+        'kind': 'user_enabled_ligature',
+        'scope': 'default_and_named',
+    },
+}
+CJK_LATIN_STRICT_GSUB_PROMOTION_TAGS = frozenset(
+    CJK_LATIN_STRICT_GSUB_PROMOTION_POLICIES)
 
 
 def _collect_subordinate_lookup_indices(lookup) -> set:
@@ -2508,7 +2533,7 @@ def _latin_feature_safe_for_cjk_promotion(feat_record, merged_lookups,
     return True
 
 
-def _sub_feature_strictly_safe_for_cjk_default_promotion(
+def _sub_feature_strictly_safe_for_cjk_gsub_promotion(
         feat_record, merged_lookups, sub_owned_glyphs):
     """Return True only when a GSUB feature is sub-font-confined.
 
@@ -2547,6 +2572,13 @@ def _sub_feature_strictly_safe_for_cjk_default_promotion(
     return saw_glyph
 
 
+def _sub_feature_strictly_safe_for_cjk_default_promotion(
+        feat_record, merged_lookups, sub_owned_glyphs):
+    """Backward-compatible wrapper for the Phase 1 `calt` helper name."""
+    return _sub_feature_strictly_safe_for_cjk_gsub_promotion(
+        feat_record, merged_lookups, sub_owned_glyphs)
+
+
 def _build_lang_sys(jp_lang_sys, lat_lang_sys, script_tag, table_tag,
                     jp_feat_index_map, lat_feat_index_map,
                     jp_feature_records, lat_feature_records,
@@ -2567,12 +2599,12 @@ def _build_lang_sys(jp_lang_sys, lat_lang_sys, script_tag, table_tag,
         cjk_extra_lat_features: list of (tag, new_merged_idx) for Latin/sub
             features promoted into CJK LangSys records. This includes
             allowlisted explicit user features (ss02, tnum, ...) and strict
-            sub-font-confined default GSUB features such as calt. Only
-            consulted when script_tag is in CJK_SCRIPTS.
+            sub-font-confined GSUB features such as calt, liga, ccmp, case,
+            and dlig. Only consulted when script_tag is in CJK_SCRIPTS.
         merged_feature_records: the merged FeatureList.FeatureRecord list
             (jp_features + lat_features, in the same order as the merged
             FeatureList). Required to support the duplicate-tag merge in
-            CJK_SCRIPTS: when an allowlist tag already lives on the JP
+            CJK_SCRIPTS: when a promoted tag already lives on the JP
             side of the current LangSys, a fresh combined FeatureRecord
             (JP lookups + Latin lookups) is appended to this list and the
             LangSys references the new index. The original JP record is
@@ -2609,7 +2641,7 @@ def _build_lang_sys(jp_lang_sys, lat_lang_sys, script_tag, table_tag,
         # apps that shape mixed Latin/CJK runs through a CJK LangSys can still
         # reach them. Explicit user features use the allowlist; default-on /
         # context-sensitive Latin tags stay excluded unless they pass the
-        # separate strict sub-font-confined policy, currently limited to calt.
+        # separate strict sub-font-confined GSUB policy.
         jp_tags_in_langsys = set()
         jp_tag_to_merged_idx = {}
         if jp_lang_sys and jp_lang_sys.FeatureIndex:
@@ -2621,20 +2653,21 @@ def _build_lang_sys(jp_lang_sys, lat_lang_sys, script_tag, table_tag,
                         tag = jp_feature_records[old_idx].FeatureTag
                         jp_tags_in_langsys.add(tag)
                         jp_tag_to_merged_idx.setdefault(tag, merged_idx)
-        # Latin user features live under Latin's `latn`/`DFLT` LangSys, not
-        # the (typically nonexistent) Latin `kana`/`hani` LangSys, so iterate
-        # the pre-computed list collected in `_merge_ot_table_v2` rather than
-        # `lat_lang_sys` (which is None for CJK script tags).
+        # Latin-side promoted features live under Latin's `latn`/`DFLT`
+        # LangSys, not the (typically nonexistent) Latin `kana`/`hani`
+        # LangSys, so iterate the pre-computed list collected in
+        # `_merge_ot_table_v2` rather than `lat_lang_sys` (which is None for
+        # CJK script tags).
         if table_tag == 'GSUB' and cjk_extra_lat_features:
             for tag, new_idx in cjk_extra_lat_features:
                 if tag not in jp_tags_in_langsys:
                     feat_indices.append(new_idx)
                     continue
                 # Duplicate tag: HarfBuzz would only fire one of two
-                # `tnum` records (the shadowing pattern that bites
-                # GSUB_LATN_DEDUPE_TAGS under `latn`). Instead of
-                # dropping the Latin promotion *or* mutating the shared
-                # JP record (which would leak the Latin lookups into
+                # same-tag records (the shadowing pattern that bites `tnum`
+                # under CJK and GSUB_LATN_DEDUPE_TAGS under `latn`). Instead
+                # of dropping the Latin promotion *or* mutating the shared JP
+                # record (which would leak the Latin lookups into
                 # every LangSys that references the same JP record by
                 # index — for example a Latin named-only `tnum`
                 # leaking into `kana/dflt`), build a fresh combined
@@ -2962,7 +2995,7 @@ def _merge_ot_table_v2(lat_table, jp_table, lat_font, jp_font, merged,
                 continue
             new_merged_idx = lat_feat_index_map[old_idx]
             merged_feat = all_features[new_merged_idx][1]
-            if not _sub_feature_strictly_safe_for_cjk_default_promotion(
+            if not _sub_feature_strictly_safe_for_cjk_gsub_promotion(
                     merged_feat, merged_lookups, lat_glyph_names):
                 continue
             seen_tags.add(tag)

--- a/python/merge_fonts.py
+++ b/python/merge_fonts.py
@@ -1538,6 +1538,14 @@ def _add_coverage_domain_glyphs(glyph_names: set, coverage) -> bool:
     return False
 
 
+def _coverage_domain_has_glyphs(coverage) -> bool:
+    if coverage is None:
+        return False
+    if isinstance(coverage, list):
+        return any(_coverage_domain_has_glyphs(cov) for cov in coverage)
+    return bool(getattr(coverage, 'glyphs', None))
+
+
 def _classdef_glyphs_by_class(class_def) -> dict[int, set[str]]:
     out = {}
     class_defs = getattr(class_def, 'classDefs', None) or {}
@@ -1617,6 +1625,8 @@ def _collect_gsub_subtable_full_domain(lookup_type: int, subtable) \
                      'LookAheadCoverage'):
         unknown = _add_coverage_domain_glyphs(
             glyph_names, getattr(st, cov_attr, None)) or unknown
+    has_input_coverage = _coverage_domain_has_glyphs(
+        getattr(st, 'Coverage', None))
 
     if lookup_type == 1:
         mapping = getattr(st, 'mapping', None)
@@ -1625,8 +1635,11 @@ def _collect_gsub_subtable_full_domain(lookup_type: int, subtable) \
             for out_glyph in mapping.values():
                 unknown = _add_substitution_output_glyphs(
                     glyph_names, out_glyph) or unknown
+        substitute = getattr(st, 'Substitute', None)
+        if substitute is not None and not mapping and not has_input_coverage:
+            unknown = True
         unknown = _add_substitution_output_glyphs(
-            glyph_names, getattr(st, 'Substitute', None)) or unknown
+            glyph_names, substitute) or unknown
 
     elif lookup_type == 2:
         mapping = getattr(st, 'mapping', None)
@@ -1635,7 +1648,10 @@ def _collect_gsub_subtable_full_domain(lookup_type: int, subtable) \
             for sequence in mapping.values():
                 unknown = _add_substitution_output_glyphs(
                     glyph_names, sequence) or unknown
-        for sequence in (getattr(st, 'Sequence', None) or []):
+        sequences = getattr(st, 'Sequence', None) or []
+        if sequences and not has_input_coverage:
+            unknown = True
+        for sequence in sequences:
             unknown = _add_substitution_output_glyphs(
                 glyph_names, getattr(sequence, 'Substitute', None)) or unknown
 
@@ -1646,7 +1662,10 @@ def _collect_gsub_subtable_full_domain(lookup_type: int, subtable) \
             for alt_set in alternates.values():
                 unknown = _add_substitution_output_glyphs(
                     glyph_names, alt_set) or unknown
-        for alt_set in (getattr(st, 'AlternateSet', None) or []):
+        alt_sets = getattr(st, 'AlternateSet', None) or []
+        if alt_sets and not has_input_coverage:
+            unknown = True
+        for alt_set in alt_sets:
             unknown = _add_substitution_output_glyphs(
                 glyph_names, getattr(alt_set, 'Alternate', None)) or unknown
 
@@ -1660,7 +1679,10 @@ def _collect_gsub_subtable_full_domain(lookup_type: int, subtable) \
                         glyph_names, getattr(lig, 'Component', None)) or unknown
                     unknown = _add_glyph(
                         glyph_names, getattr(lig, 'LigGlyph', None)) or unknown
-        for lig_set in (getattr(st, 'LigatureSet', None) or []):
+        lig_sets = getattr(st, 'LigatureSet', None) or []
+        if lig_sets and not has_input_coverage:
+            unknown = True
+        for lig_set in lig_sets:
             for lig in (getattr(lig_set, 'Ligature', None) or []):
                 unknown = _add_glyph_sequence(
                     glyph_names, getattr(lig, 'Component', None)) or unknown
@@ -1731,8 +1753,11 @@ def _collect_gsub_subtable_full_domain(lookup_type: int, subtable) \
         unknown = True
 
     elif lookup_type == 8:
+        substitute = getattr(st, 'Substitute', None)
+        if substitute is not None and not has_input_coverage:
+            unknown = True
         unknown = _add_substitution_output_glyphs(
-            glyph_names, getattr(st, 'Substitute', None)) or unknown
+            glyph_names, substitute) or unknown
 
     else:
         unknown = True
@@ -2401,18 +2426,12 @@ CJK_SCRIPTS = {'kana', 'hani', 'hang', 'bopo', 'yi  '}
 GSUB_LATN_DEDUPE_TAGS = frozenset({'ccmp', 'dlig'})
 
 
-# Latin user-toggle GSUB features that should also be reachable from CJK
-# script LangSys records (`kana` / `hani` / ...). Apps such as Adobe
-# Illustrator may shape mixed Latin/CJK runs through a CJK script's
-# LangSys instead of splitting into a separate `latn` run; without this
-# allowlist the user's `ss02` / `tnum` toggle silently no-ops on Latin
-# glyphs whenever the run also contains a Japanese character.
-#
-# Restricted to explicit *user* features. Default-on, context-sensitive, or
-# semantically special GSUB tags (`calt`, `liga`, `ccmp`, `case`, `dlig`)
-# remain out of this allowlist and use the strict full-domain policy below.
-# Language/alternate/CJK-layout tags (`locl`, `aalt`, `fwid`, `hwid`, `vert`,
-# `vrt2`) remain out of scope for cross-script Latin/sub promotion.
+# Restricted to explicit user-selected Latin/sub features. Default-on,
+# context-sensitive, or semantically special GSUB tags (`calt`, `liga`,
+# `ccmp`, `case`, `dlig`) remain out of this allowlist and use the strict
+# full-domain GSUB promotion policy below. Language/alternate/CJK-layout
+# tags (`locl`, `aalt`, `fwid`, `hwid`, `vert`, `vrt2`) remain out of scope
+# for cross-script Latin/sub promotion.
 # See `docs/CJK_LATIN_USER_FEATURES_PLAN.md`.
 CJK_LATIN_USER_FEATURE_ALLOWLIST = frozenset(
     {f'ss{n:02d}' for n in range(1, 21)}    # ss01..ss20

--- a/python/tests/test_cjk_latin_user_features.py
+++ b/python/tests/test_cjk_latin_user_features.py
@@ -569,6 +569,28 @@ class TestLatinUserFeaturesUnderCjkScripts:
             f"prefix: {script}={cjk[:len(latn)]} vs latn={latn}"
         )
 
+    @pytest.mark.parametrize("feature,latin_text", [
+        ("case", "()"),
+        ("dlig", "fi"),
+    ])
+    @pytest.mark.parametrize("script,language", [("kana", "ja"), ("hani", "ja")])
+    def test_case_and_dlig_under_cjk_are_not_default_on(
+            self, merged_inter_path, feature, latin_text, script, language):
+        mixed_text = f"{latin_text} 日本語"
+        latn_default = _shape(merged_inter_path, latin_text, "latn", "en")
+        latn_enabled = _shape(
+            merged_inter_path, latin_text, "latn", "en", {feature: True})
+        assert latn_default != latn_enabled, (
+            f"fixture sanity: {feature}=1 should affect {latin_text!r}"
+        )
+
+        cjk_default = _shape(merged_inter_path, mixed_text, script, language)
+        assert cjk_default[:len(latn_default)] == latn_default, (
+            f"{script}/{language} default shaping unexpectedly enabled "
+            f"{feature}: {script}={cjk_default[:len(latn_default)]} "
+            f"vs latn default={latn_default}"
+        )
+
 
 class TestCjkScriptShapingUnchangedForJapanese:
     """Plain Japanese text shaped under CJK scripts must not be affected by
@@ -1437,6 +1459,61 @@ class TestStrictCaltSafetyHelper:
         feat_rec = _make_feature_record("calt", [1])
         assert mf._sub_feature_strictly_safe_for_cjk_default_promotion(
             feat_rec, [sub, chain], {"A", "A.alt", "colon"}) is True
+
+    def test_rejects_multiple_subst_sequence_without_coverage(self):
+        from fontTools.ttLib.tables import otTables
+        sequence = otTables.Sequence()
+        sequence.Substitute = ["M", "gravecomb"]
+        sequence.GlyphCount = len(sequence.Substitute)
+        st = otTables.MultipleSubst()
+        st.Sequence = [sequence]
+        st.SequenceCount = len(st.Sequence)
+        lookup = otTables.Lookup()
+        lookup.LookupType = 2
+        lookup.LookupFlag = 0
+        lookup.SubTable = [st]
+        lookup.SubTableCount = 1
+        feat_rec = _make_feature_record("ccmp", [0])
+        assert mf._sub_feature_strictly_safe_for_cjk_gsub_promotion(
+            feat_rec, [lookup], {"M", "gravecomb"}) is False
+
+    def test_rejects_alternate_subst_set_without_coverage(self):
+        from fontTools.ttLib.tables import otTables
+        alt_set = otTables.AlternateSet()
+        alt_set.Alternate = ["A.alt"]
+        alt_set.AlternateCount = len(alt_set.Alternate)
+        st = otTables.AlternateSubst()
+        st.AlternateSet = [alt_set]
+        st.AlternateSetCount = len(st.AlternateSet)
+        lookup = otTables.Lookup()
+        lookup.LookupType = 3
+        lookup.LookupFlag = 0
+        lookup.SubTable = [st]
+        lookup.SubTableCount = 1
+        feat_rec = _make_feature_record("salt", [0])
+        assert mf._sub_feature_strictly_safe_for_cjk_gsub_promotion(
+            feat_rec, [lookup], {"A.alt"}) is False
+
+    def test_rejects_ligature_subst_set_without_coverage(self):
+        from fontTools.ttLib.tables import otTables
+        lig = otTables.Ligature()
+        lig.Component = ["i"]
+        lig.CompCount = len(lig.Component) + 1
+        lig.LigGlyph = "f_i"
+        lig_set = otTables.LigatureSet()
+        lig_set.Ligature = [lig]
+        lig_set.LigatureCount = len(lig_set.Ligature)
+        st = otTables.LigatureSubst()
+        st.LigatureSet = [lig_set]
+        st.LigatureSetCount = len(st.LigatureSet)
+        lookup = otTables.Lookup()
+        lookup.LookupType = 4
+        lookup.LookupFlag = 0
+        lookup.SubTable = [st]
+        lookup.SubTableCount = 1
+        feat_rec = _make_feature_record("liga", [0])
+        assert mf._sub_feature_strictly_safe_for_cjk_gsub_promotion(
+            feat_rec, [lookup], {"i", "f_i"}) is False
 
 
 class TestStrictCaltPromotionStructure:

--- a/python/tests/test_cjk_latin_user_features.py
+++ b/python/tests/test_cjk_latin_user_features.py
@@ -11,13 +11,18 @@ Background:
     See ``docs/CJK_LATIN_USER_FEATURES_PLAN.md``.
 """
 
+import os
+
 import pytest
 
 from fontTools.ttLib import TTFont
 
-from conftest import EN_VAR, JP_VAR
+from conftest import EN_VAR, FONTS, JP_VAR
 
 import merge_fonts as mf
+
+
+CHARIS = os.path.join(FONTS, "Charis_SIL", "CharisSIL-Regular.ttf")
 
 
 def _coverage(*glyphs):
@@ -33,6 +38,34 @@ def _make_single_subst(input_glyph, output_glyph):
     st.mapping = {input_glyph: output_glyph}
     lk = otTables.Lookup()
     lk.LookupType = 1
+    lk.LookupFlag = 0
+    lk.SubTable = [st]
+    lk.SubTableCount = 1
+    return lk
+
+
+def _make_multiple_subst(input_glyph, output_glyphs):
+    from fontTools.ttLib.tables import otTables
+    st = otTables.MultipleSubst()
+    st.mapping = {input_glyph: list(output_glyphs)}
+    lk = otTables.Lookup()
+    lk.LookupType = 2
+    lk.LookupFlag = 0
+    lk.SubTable = [st]
+    lk.SubTableCount = 1
+    return lk
+
+
+def _make_ligature_subst(first_glyph, component_glyphs, ligature_glyph):
+    from fontTools.ttLib.tables import otTables
+    lig = otTables.Ligature()
+    lig.Component = list(component_glyphs)
+    lig.CompCount = len(lig.Component) + 1
+    lig.LigGlyph = ligature_glyph
+    st = otTables.LigatureSubst()
+    st.ligatures = {first_glyph: [lig]}
+    lk = otTables.Lookup()
+    lk.LookupType = 4
     lk.LookupFlag = 0
     lk.SubTable = [st]
     lk.SubTableCount = 1
@@ -270,6 +303,35 @@ def _feature_indices_for_tag(gsub, langsys, tag):
     ]
 
 
+PHASE2_STRICT_GSUB_TAGS = ("liga", "ccmp", "case", "dlig")
+
+
+def _safe_lookup_for_strict_tag(tag):
+    if tag in ("liga", "dlig"):
+        return _make_ligature_subst("f", ["i"], "f_i"), {"f", "i", "f_i"}
+    if tag == "ccmp":
+        return _make_multiple_subst(
+            "Mgrave", ["M", "gravecomb"]), {"Mgrave", "M", "gravecomb"}
+    if tag == "case":
+        return _make_single_subst(
+            "parenleft", "parenleft.case"), {"parenleft", "parenleft.case"}
+    if tag == "calt":
+        return _make_single_subst("A", "A.alt"), {"A", "A.alt"}
+    raise AssertionError(f"unknown strict tag fixture: {tag}")
+
+
+def _unsafe_lookup_for_strict_tag(tag):
+    if tag in ("liga", "dlig"):
+        return _make_ligature_subst("f", ["i"], "uni65E5"), {"f", "i"}
+    if tag == "ccmp":
+        return _make_multiple_subst("Mgrave", ["M", "uni65E5"]), {"Mgrave", "M"}
+    if tag == "case":
+        return _make_single_subst("parenleft", "uni65E5"), {"parenleft"}
+    if tag == "calt":
+        return _make_single_subst("A", "uni65E5"), {"A"}
+    raise AssertionError(f"unknown strict tag fixture: {tag}")
+
+
 # ---------------------------------------------------------------------------
 # Shared HarfBuzz helper
 # ---------------------------------------------------------------------------
@@ -315,6 +377,30 @@ def merged_inter_path(tmp_path_factory):
             "axes": [{"tag": "wght", "currentValue": 400}],
         },
         "output": {"familyName": "TestCjkLatinFeatures"},
+        "export": {"path": {"font": str(out)}},
+    }
+    mf.merge_fonts(config)
+    return str(out)
+
+
+@pytest.fixture(scope="module")
+def merged_charis_path(tmp_path_factory):
+    """Merge Charis SIL onto Noto Sans JP for a standard-liga fixture."""
+    out = tmp_path_factory.mktemp("cjk_latin_liga") / "merged.ttf"
+    config = {
+        "subFont": {
+            "path": CHARIS,
+            "scale": 1.0,
+            "baselineOffset": 0,
+            "axes": [],
+        },
+        "baseFont": {
+            "path": JP_VAR,
+            "scale": 1.0,
+            "baselineOffset": 0,
+            "axes": [{"tag": "wght", "currentValue": 400}],
+        },
+        "output": {"familyName": "TestCjkLatinLiga"},
         "export": {"path": {"font": str(out)}},
     }
     mf.merge_fonts(config)
@@ -416,6 +502,73 @@ class TestLatinUserFeaturesUnderCjkScripts:
             f"prefix: {script}={cjk[:len(latn)]} vs latn={latn}"
         )
 
+    @pytest.mark.parametrize("script,language", [("kana", "ja"), ("hani", "ja")])
+    def test_liga_under_cjk_matches_latn_prefix(
+            self, merged_charis_path, script, language):
+        latin_text = "office"
+        mixed_text = f"{latin_text} 日本語"
+        latn = _shape(merged_charis_path, latin_text, "latn", "en")
+        latn_without_liga = _shape(
+            merged_charis_path, latin_text, "latn", "en", {"liga": False})
+        assert latn != latn_without_liga, (
+            "fixture sanity: Charis liga should affect 'office' under latn"
+        )
+        cjk = _shape(merged_charis_path, mixed_text, script, language)
+        assert cjk[:len(latn)] == latn, (
+            f"{script}/{language} liga differs from latn/en for the Latin "
+            f"prefix: {script}={cjk[:len(latn)]} vs latn={latn}"
+        )
+
+    @pytest.mark.parametrize("script,language", [("kana", "ja"), ("hani", "ja")])
+    def test_ccmp_under_cjk_matches_latn_prefix(
+            self, merged_inter_path, script, language):
+        latin_text = "M̀"
+        mixed_text = f"{latin_text} 日本語"
+        latn = _shape(merged_inter_path, latin_text, "latn", "en")
+        cjk = _shape(merged_inter_path, mixed_text, script, language)
+        assert cjk[:len(latn)] == latn, (
+            f"{script}/{language} ccmp differs from latn/en for the Latin "
+            f"prefix: {script}={cjk[:len(latn)]} vs latn={latn}"
+        )
+
+    @pytest.mark.parametrize("script,language", [("kana", "ja"), ("hani", "ja")])
+    def test_case_under_cjk_when_enabled_matches_latn_prefix(
+            self, merged_inter_path, script, language):
+        latin_text = "()"
+        mixed_text = f"{latin_text} 日本語"
+        latn = _shape(merged_inter_path, latin_text, "latn", "en",
+                      {"case": True})
+        latn_without_case = _shape(
+            merged_inter_path, latin_text, "latn", "en", {"case": False})
+        assert latn != latn_without_case, (
+            "fixture sanity: Inter case should affect parentheses under latn"
+        )
+        cjk = _shape(merged_inter_path, mixed_text, script, language,
+                     {"case": True})
+        assert cjk[:len(latn)] == latn, (
+            f"{script}/{language} case=1 differs from latn/en for the Latin "
+            f"prefix: {script}={cjk[:len(latn)]} vs latn={latn}"
+        )
+
+    @pytest.mark.parametrize("script,language", [("kana", "ja"), ("hani", "ja")])
+    def test_dlig_under_cjk_when_enabled_matches_latn_prefix(
+            self, merged_inter_path, script, language):
+        latin_text = "fi"
+        mixed_text = f"{latin_text} 日本語"
+        latn = _shape(merged_inter_path, latin_text, "latn", "en",
+                      {"dlig": True})
+        latn_without_dlig = _shape(
+            merged_inter_path, latin_text, "latn", "en", {"dlig": False})
+        assert latn != latn_without_dlig, (
+            "fixture sanity: Inter dlig should affect 'fi' under latn"
+        )
+        cjk = _shape(merged_inter_path, mixed_text, script, language,
+                     {"dlig": True})
+        assert cjk[:len(latn)] == latn, (
+            f"{script}/{language} dlig=1 differs from latn/en for the Latin "
+            f"prefix: {script}={cjk[:len(latn)]} vs latn={latn}"
+        )
+
 
 class TestCjkScriptShapingUnchangedForJapanese:
     """Plain Japanese text shaped under CJK scripts must not be affected by
@@ -430,6 +583,8 @@ class TestCjkScriptShapingUnchangedForJapanese:
         {"ss02": True},
         {"tnum": True},
         {"ss01": True, "ss02": True, "tnum": True, "zero": True},
+        {"case": True},
+        {"dlig": True, "liga": True},
     ])
     @pytest.mark.parametrize("script,language", [("kana", "ja"), ("hani", "ja")])
     def test_japanese_text_unchanged(self, merged_inter_path,
@@ -500,32 +655,55 @@ class TestCjkLangSysIncludesAllowlistedLatinFeatures:
             )
 
 
-class TestCjkLangSysIncludesStrictSafeCalt:
-    """Strictly sub-font-confined Latin ``calt`` may be promoted to CJK
-    LangSys records even though it is not a user-feature allowlist tag."""
+class TestCjkLangSysIncludesStrictSafeGsubTags:
+    """Strictly sub-font-confined Latin GSUB tags may be promoted to CJK
+    LangSys records even though they are not user-feature allowlist tags."""
 
     @pytest.mark.parametrize("script", ["kana", "hani"])
-    def test_inter_calt_promoted_under_cjk_default(self, merged_inter_path,
-                                                  script):
+    def test_inter_strict_gsub_tags_promoted_under_cjk_default(
+            self, merged_inter_path, script):
         merged = TTFont(merged_inter_path)
         gsub = merged["GSUB"].table
         ls = _langsys(gsub, script)
         assert ls is not None, f"merged font has no {script} DefaultLangSys"
         tags = set(_tags_for_langsys(gsub, ls))
-        assert "calt" in tags, (
-            f"{script} DefaultLangSys missing strict Latin calt promotion "
-            f"(tags={sorted(tags)})"
+        inter = TTFont(EN_VAR)
+        inter_gsub = inter["GSUB"].table
+        inter_features = inter_gsub.FeatureList.FeatureRecord
+        inter_latn_default_tags = set()
+        for sr in inter_gsub.ScriptList.ScriptRecord:
+            if sr.ScriptTag not in ("latn", "DFLT"):
+                continue
+            ds = sr.Script.DefaultLangSys
+            if ds:
+                inter_latn_default_tags.update(
+                    inter_features[i].FeatureTag
+                    for i in (ds.FeatureIndex or [])
+                )
+        expected_tags = (
+            mf.CJK_LATIN_STRICT_GSUB_PROMOTION_TAGS
+            & inter_latn_default_tags
         )
+        assert expected_tags, "fixture must expose strict GSUB tags"
+        for expected in expected_tags:
+            assert expected in tags, (
+                f"{script} DefaultLangSys missing strict Latin {expected} "
+                f"promotion (tags={sorted(tags)})"
+            )
 
-    def test_calt_stays_out_of_user_allowlist(self):
-        assert "calt" not in mf.CJK_LATIN_USER_FEATURE_ALLOWLIST
+    @pytest.mark.parametrize("tag", ("calt",) + PHASE2_STRICT_GSUB_TAGS)
+    def test_strict_gsub_tags_stay_out_of_user_allowlist(self, tag):
+        assert tag not in mf.CJK_LATIN_USER_FEATURE_ALLOWLIST
+
+    def test_strict_gsub_policy_tags_are_phase2_scope(self):
+        assert mf.CJK_LATIN_STRICT_GSUB_PROMOTION_TAGS == frozenset(
+            ("calt",) + PHASE2_STRICT_GSUB_TAGS)
 
 
 class TestCjkLangSysExcludesAvoidedTags:
     """The fix must not blindly copy every Latin feature into CJK LangSys
-    records. Defaults / context-sensitive features other than strictly safe
-    ``calt`` must not become reachable from CJK scripts unless they were
-    already on the JP side.
+    records. Tags still outside the strict policy must not become reachable
+    from CJK scripts unless they were already on the JP side.
     """
 
     # Full avoid list from docs/CJK_LATIN_USER_FEATURES_PLAN.md. Tags the
@@ -533,7 +711,6 @@ class TestCjkLangSysExcludesAvoidedTags:
     # (preserving JP-owned `fwid` / `vert` is correct); the test only
     # flags tags newly inherited from the Latin side.
     AVOIDED_TAGS = (
-        "case", "ccmp", "liga", "dlig",
         "aalt", "locl", "fwid", "hwid", "vert", "vrt2",
     )
 
@@ -1341,6 +1518,106 @@ class TestStrictCaltPromotionStructure:
         assert "calt" not in _tags_for_langsys(gsub, default_ls)
         assert named_ls is not None
         assert "calt" in _tags_for_langsys(gsub, named_ls)
+
+
+class TestStrictPhase2GsubPromotionStructure:
+    """Phase 2 tags reuse the strict full-domain promotion policy."""
+
+    @staticmethod
+    def _latn_default_gsub_for_tag(tag, lookup, lat_glyph_names):
+        return _merge_minimal_gsub(
+            [lookup],
+            [_make_feature_record(tag, [0])],
+            [_make_script_record("latn", [0])],
+            lat_glyph_names=lat_glyph_names,
+        )
+
+    @pytest.mark.parametrize("tag", PHASE2_STRICT_GSUB_TAGS)
+    @pytest.mark.parametrize("script", ["kana", "hani"])
+    def test_safe_feature_is_promoted_to_cjk_default(self, tag, script):
+        lookup, sub_owned = _safe_lookup_for_strict_tag(tag)
+        gsub = self._latn_default_gsub_for_tag(tag, lookup, sub_owned)
+        ls = _langsys(gsub, script)
+        assert tag in _tags_for_langsys(gsub, ls)
+
+    @pytest.mark.parametrize("tag", PHASE2_STRICT_GSUB_TAGS)
+    @pytest.mark.parametrize("script", ["kana", "hani"])
+    def test_unsafe_output_feature_is_not_promoted(self, tag, script):
+        lookup, sub_owned = _unsafe_lookup_for_strict_tag(tag)
+        gsub = self._latn_default_gsub_for_tag(tag, lookup, sub_owned)
+        ls = _langsys(gsub, script)
+        assert tag not in _tags_for_langsys(gsub, ls)
+
+    @pytest.mark.parametrize("tag", ["liga", "dlig"])
+    @pytest.mark.parametrize("script", ["kana", "hani"])
+    def test_unsafe_ligature_component_is_not_promoted(self, tag, script):
+        lookup = _make_ligature_subst("f", ["uni65E5"], "f_uni65E5")
+        gsub = self._latn_default_gsub_for_tag(
+            tag, lookup, {"f", "f_uni65E5"})
+        ls = _langsys(gsub, script)
+        assert tag not in _tags_for_langsys(gsub, ls)
+
+    @pytest.mark.parametrize("tag", PHASE2_STRICT_GSUB_TAGS)
+    @pytest.mark.parametrize("script", ["kana", "hani"])
+    def test_duplicate_tag_combines_without_mutating_jp_record(
+            self, tag, script):
+        jp_lookup = _make_single_subst("uni65E5", "uni65E5.alt")
+        lat_lookup, sub_owned = _safe_lookup_for_strict_tag(tag)
+        gsub = _merge_minimal_gsub(
+            [lat_lookup],
+            [_make_feature_record(tag, [0])],
+            [_make_script_record("latn", [0])],
+            jp_lookups=[jp_lookup],
+            jp_features=[_make_feature_record(tag, [0])],
+            jp_scripts=[
+                _make_script_record("kana", [0]),
+                _make_script_record("hani", [0]),
+            ],
+            lat_glyph_names=sub_owned,
+        )
+        ls = _langsys(gsub, script)
+        tags = _tags_for_langsys(gsub, ls)
+        assert tags.count(tag) == 1
+        [combined_idx] = _feature_indices_for_tag(gsub, ls, tag)
+        combined_lookups = (
+            gsub.FeatureList.FeatureRecord[combined_idx]
+            .Feature.LookupListIndex
+        )
+        assert combined_lookups == [0, 1]
+        original_jp_lookups = (
+            gsub.FeatureList.FeatureRecord[0].Feature.LookupListIndex
+        )
+        assert original_jp_lookups == [0]
+
+    @pytest.mark.parametrize("tag", PHASE2_STRICT_GSUB_TAGS)
+    @pytest.mark.parametrize("script", ["kana", "hani"])
+    def test_named_only_feature_does_not_leak_to_cjk_default(
+            self, tag, script):
+        lookup, sub_owned = _safe_lookup_for_strict_tag(tag)
+        gsub = _merge_minimal_gsub(
+            [lookup],
+            [_make_feature_record(tag, [0])],
+            [_make_script_record("latn", [], named={"JPN ": [0]})],
+            lat_glyph_names=sub_owned,
+        )
+        default_ls = _langsys(gsub, script)
+        named_ls = _langsys(gsub, script, "JPN ")
+        assert tag not in _tags_for_langsys(gsub, default_ls)
+        assert named_ls is not None
+        assert tag in _tags_for_langsys(gsub, named_ls)
+
+    @pytest.mark.parametrize("tag", PHASE2_STRICT_GSUB_TAGS)
+    @pytest.mark.parametrize("script", ["kana", "hani"])
+    def test_orphan_feature_record_is_not_promoted(self, tag, script):
+        lookup, sub_owned = _safe_lookup_for_strict_tag(tag)
+        gsub = _merge_minimal_gsub(
+            [lookup],
+            [_make_feature_record(tag, [0])],
+            [_make_script_record("latn", [])],
+            lat_glyph_names=sub_owned,
+        )
+        ls = _langsys(gsub, script)
+        assert tag not in _tags_for_langsys(gsub, ls)
 
 
 class TestSafetyHelperRecursesIntoSubordinateLookups:


### PR DESCRIPTION
## Summary

- broaden strict CJK LangSys GSUB promotion from `calt` to `calt`, `liga`, `ccmp`, `case`, and `dlig`
- keep these tags out of `CJK_LATIN_USER_FEATURE_ALLOWLIST` and route them through a separate strict policy table
- add real-font CJK shaping smoke coverage for `liga`, `ccmp`, `case`, and `dlig`, plus synthetic structural coverage for safety, duplicate-tag merge, named-only scoping, and orphan rejection

## Why

Follow-up to #29 and Phase 1. Some apps shape mixed Latin/CJK runs through CJK scripts such as `kana` / `hani`; default or app-enabled Latin/sub GSUB behavior can become unreachable unless the feature is also visible from those CJK LangSys records.

Phase 2 keeps the same strict invariant from Phase 1: a promoted feature's full lookup closure must be sub-font-confined, including inputs, context glyphs, outputs, and subordinate lookups. Unknown lookup shapes remain unsafe.

## Review Follow-up

- Confirmed that the stale calt-only strict tag constant (`frozenset({'calt'})`) is not present on this branch.
- Consolidated the allowlist comment so it clearly says `calt`, `liga`, `ccmp`, `case`, and `dlig` are handled by the strict full-domain policy instead of the explicit user-feature allowlist.
- Added regression coverage proving `case` and `dlig` are reachable from CJK scripts only when explicitly enabled; they are not forced on by default.
- Hardened strict GSUB safety collection so low-level array-shaped subtables without usable input `Coverage` are treated as unsafe. This covers `Substitute`, `Sequence`, `AlternateSet`, and `LigatureSet` forms where the input glyph domain cannot be proven.

## Notes

- `locl`, `aalt`, `fwid`, `hwid`, `vert`, `vrt2`, and GPOS positioning features remain out of scope.
- `case` and `dlig` are only made reachable; they are not forced on.
- `liga` behavioral coverage uses Charis SIL because the bundled Inter subset does not expose standard `liga`.

## Validation

- `python3 -m py_compile python/merge_fonts.py python/tests/test_cjk_latin_user_features.py` -> passed
- `PYTHONPATH=python python3 -m pytest python/tests/test_cjk_latin_user_features.py -q -k "Strict or calt or liga or ccmp or case or dlig"` -> 92 passed, 48 deselected
- `PYTHONPATH=python python3 -m pytest python/tests/test_cjk_latin_user_features.py -q` -> 140 passed
- `PYTHONPATH=python python3 -m pytest python/tests/test_filter_subordinate_lookups.py -q` -> 7 passed
- `PYTHONPATH=python python3 -m pytest python/tests/test_glyph_data.py -q -k "calt or liga or dlig or ccmp or case or subordinate or LangSys or lookup or DigitNoLeak or aalt"` -> 53 passed, 1 skipped, 147 deselected
- `npm run build` -> passed, with existing Vite chunk-size/browser-compatibility warnings
- `npm test` -> 545 passed, 1 skipped in 1762.79s (0:29:22)
