### PR TITLE
[codex] Fix output UPM scaling for unmapped base glyphs

### DIFF
--- a/python/merge_fonts.py
+++ b/python/merge_fonts.py
@@ -547,9 +547,11 @@ def parse_codepoint_list(values) -> set:
 
 def convert_cff_glyphs_to_tt(src_font: TTFont, dst_font: TTFont,
                               glyph_names: list, scale: float, dy: float,
-                              on_progress=None, name_map: dict = None):
+                              on_progress=None, copied: set = None,
+                              name_map: dict = None):
     """
     Batch-convert CFF glyphs from src_font into dst_font's glyf table.
+    copied: optional set of destination names already owned by the sub font.
     name_map: optional dict mapping src glyph names to dst glyph names.
     """
     from fontTools.pens.cu2quPen import Cu2QuPen
@@ -577,6 +579,8 @@ def convert_cff_glyphs_to_tt(src_font: TTFont, dst_font: TTFont,
             glyph = TTGlyph()
 
         dst_font["glyf"][dst_name] = glyph
+        if copied is not None:
+            copied.add(dst_name)
 
         if glyph_name in src_font["hmtx"].metrics:
             orig_aw, orig_lsb = src_font["hmtx"].metrics[glyph_name]
@@ -4273,6 +4277,31 @@ def _scale_jp_metrics(merged: TTFont, ratio: float):
             if v is not None:
                 setattr(hhea, attr, _r(v))
 
+    vhea = merged.get("vhea")
+    if vhea is not None:
+        for attr in ("ascent", "descent", "lineGap",
+                     "advanceHeightMax",
+                     "minTopSideBearing", "minBottomSideBearing",
+                     "yMaxExtent", "caretOffset"):
+            v = getattr(vhea, attr, None)
+            if v is not None:
+                setattr(vhea, attr, _r(v))
+
+    vmtx = merged.get("vmtx")
+    if vmtx is not None:
+        for gname, (advance, tsb) in list(vmtx.metrics.items()):
+            vmtx.metrics[gname] = (_r(advance), _r(tsb))
+
+    vorg = merged.get("VORG")
+    if vorg is not None:
+        default_y = getattr(vorg, "defaultVertOriginY", None)
+        if default_y is not None:
+            vorg.defaultVertOriginY = _r(default_y)
+        records = getattr(vorg, "VOriginRecords", None)
+        if records is not None:
+            for gname, y_origin in list(records.items()):
+                records[gname] = _r(y_origin)
+
     post = merged.get("post")
     if post is not None:
         for attr in ("underlinePosition", "underlineThickness"):
@@ -4666,6 +4695,7 @@ def merge_fonts(config: dict) -> str:
                 copied.add(dst)
             convert_cff_glyphs_to_tt(lat_font, merged, unique_lat_glyphs,
                                       final_lat_scale, lat_baseline,
+                                      copied=copied,
                                       name_map=lat_to_merged_name)
 
         elif not lat_is_cff and merged_is_tt:
@@ -4859,11 +4889,10 @@ def merge_fonts(config: dict) -> str:
     # Step 7: Apply transforms to Japanese glyphs (always, even without Latin font)
     if (jp_scale_eff != 1.0 or jp_baseline_eff != 0) and not _jp_transform_done:
         progress("merging-glyphs", 6, f"3/{S} \u00b7 Merging features...")
-        merged_cmap = build_cmap(merged)
-        jp_glyph_names = set()
-        for cp, gname in merged_cmap.items():
-            if gname not in copied:
-                jp_glyph_names.add(gname)
+        jp_glyph_names = [
+            gname for gname in merged.getGlyphOrder()
+            if gname not in copied
+        ]
 
         if merged_is_tt:
             for gname in jp_glyph_names:

--- a/python/tests/test_glyph_data.py
+++ b/python/tests/test_glyph_data.py
@@ -1726,6 +1726,114 @@ class TestOutputUpm:
         os.remove(out)
         assert m["head"].unitsPerEm == 1500
 
+    def test_base_only_upm_scales_unmapped_glyphs(self):
+        out = tempfile.mktemp(suffix=".ttf")
+        base_cfg = {
+            "path": JP_VAR,
+            "scale": 1.0,
+            "baselineOffset": 0,
+            "axes": [{"tag": "wght", "currentValue": 400}],
+        }
+        config = {
+            "subFont": None,
+            "baseFont": base_cfg,
+            "output": {"familyName": "Test", "upm": 2000},
+            "export": {"path": {"font": out}},
+        }
+
+        source = TTFont(JP_VAR)
+        source = mf._instantiate_if_variable(source, base_cfg, "Test source")
+        source_cmap_names = set((source.getBestCmap() or {}).values())
+        gname = None
+        source_bounds = None
+        for candidate in source.getGlyphOrder():
+            if candidate == ".notdef" or candidate in source_cmap_names:
+                continue
+            if candidate not in source["hmtx"].metrics:
+                continue
+            bounds = _get_bounds(source, candidate)
+            if bounds is None:
+                continue
+            gname = candidate
+            source_bounds = bounds
+            break
+
+        assert gname is not None, "fixture should contain an unmapped outline glyph"
+        source_hmtx = source["hmtx"].metrics[gname]
+        source_vmtx = None
+        if "vmtx" in source and gname in source["vmtx"].metrics:
+            source_vmtx = source["vmtx"].metrics[gname]
+
+        m = None
+        try:
+            mf.merge_fonts(config)
+            m = TTFont(out)
+            ratio = 2000 / source["head"].unitsPerEm
+
+            assert m["head"].unitsPerEm == 2000
+            assert m["hmtx"].metrics[gname] == (
+                int(round(source_hmtx[0] * ratio)),
+                int(round(source_hmtx[1] * ratio)),
+            )
+            if source_vmtx is not None:
+                assert m["vmtx"].metrics[gname] == (
+                    int(round(source_vmtx[0] * ratio)),
+                    int(round(source_vmtx[1] * ratio)),
+                )
+
+            expected_bounds = tuple(int(round(v * ratio)) for v in source_bounds)
+            actual_bounds = _get_bounds(m, gname)
+            assert actual_bounds is not None
+            for actual, expected in zip(actual_bounds, expected_bounds):
+                assert abs(actual - expected) <= 2
+        finally:
+            source.close()
+            if m is not None:
+                m.close()
+            for path in (out, out.replace(".ttf", ".woff2")):
+                if os.path.exists(path):
+                    os.remove(path)
+
+    def test_cff_subfont_upm_scaling_is_not_applied_twice(self):
+        out = tempfile.mktemp(suffix=".ttf")
+        config = {
+            "subFont": {
+                "path": EN_CFF,
+                "scale": 1.0,
+                "baselineOffset": 0,
+                "axes": [],
+            },
+            "baseFont": {
+                "path": JP_VAR,
+                "scale": 1.0,
+                "baselineOffset": 0,
+                "axes": [{"tag": "wght", "currentValue": 400}],
+            },
+            "output": {"familyName": "Test", "upm": 2000},
+            "export": {"path": {"font": out}},
+        }
+
+        sub = TTFont(EN_CFF)
+        m = None
+        try:
+            mf.merge_fonts(config)
+            m = TTFont(out)
+            merged_gname = m.getBestCmap()[0x0048]
+            sub_gname = sub.getBestCmap()[0x0048]
+            ratio = 2000 / sub["head"].unitsPerEm
+            expected_hmtx = (
+                int(round(sub["hmtx"].metrics[sub_gname][0] * ratio)),
+                int(round(sub["hmtx"].metrics[sub_gname][1] * ratio)),
+            )
+            assert m["hmtx"].metrics[merged_gname] == expected_hmtx
+        finally:
+            sub.close()
+            if m is not None:
+                m.close()
+            for path in (out, out.replace(".ttf", ".woff2")):
+                if os.path.exists(path):
+                    os.remove(path)
+
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- scale base-origin glyphs from the full glyph order when `output.upm` changes, so unmapped glyphs no longer stay on the source UPM grid
- scale vertical metrics tables (`vhea`, `vmtx`, `VORG`) alongside the existing horizontal/global metrics
- add regression coverage for base-only unmapped glyph UPM scaling and CFF subfont copy paths avoiding double scaling

## Root Cause

The JP/base transform pass built its target glyph set from `cmap`, so glyphs present only in glyph order, such as vertical alternates, were skipped. The output `head.unitsPerEm` changed, but those glyphs retained source-grid outlines and metrics.

Fixes #32.

## Validation

- `PYTHONPATH=python python3 -m pytest python/tests -q` -> `547 passed, 1 skipped`
- `python3 -m py_compile python/merge_fonts.py`
- manual full Noto Sans JP variable probe confirmed `glyph16635` and `glyph16754` advances scale to 2048 in an `output.upm = 2048` base-only bake
