### PR TITLE
Fix output UPM layout scaling

### DIFF
--- a/python/merge_fonts.py
+++ b/python/merge_fonts.py
@@ -3189,7 +3189,11 @@ def _scale_gpos_subtable(st, scale: float, dy: float):
     """
     # SinglePos (type 1)
     if hasattr(st, 'Value') and st.Value:
-        _scale_value_record(st.Value, scale)
+        if isinstance(st.Value, (list, tuple)):
+            for value_record in st.Value:
+                _scale_value_record(value_record, scale)
+        else:
+            _scale_value_record(st.Value, scale)
     if hasattr(st, 'Value1') and st.Value1:
         _scale_value_record(st.Value1, scale)
     if hasattr(st, 'Value2') and st.Value2:
@@ -4309,12 +4313,52 @@ def _scale_jp_metrics(merged: TTFont, ratio: float):
             if v is not None:
                 setattr(post, attr, _r(v))
 
+    base = merged.get("BASE")
+    if base is not None:
+        _scale_base_table(base.table, ratio)
+
     head = merged.get("head")
     if head is not None:
         for attr in ("xMin", "yMin", "xMax", "yMax"):
             v = getattr(head, attr, None)
             if v is not None:
                 setattr(head, attr, _r(v))
+
+
+def _scale_base_table(table, ratio: float):
+    """Scale OpenType BASE coordinates for output-UPM changes."""
+    if ratio == 1.0:
+        return
+
+    def _r(v):
+        return int(round(v * ratio))
+
+    seen = set()
+
+    def _walk(obj):
+        if obj is None:
+            return
+        if isinstance(obj, (str, bytes, int, float, bool)):
+            return
+        if isinstance(obj, (list, tuple)):
+            for item in obj:
+                _walk(item)
+            return
+
+        obj_id = id(obj)
+        if obj_id in seen:
+            return
+        seen.add(obj_id)
+
+        if hasattr(obj, "Coordinate"):
+            coord = getattr(obj, "Coordinate")
+            if isinstance(coord, int):
+                setattr(obj, "Coordinate", _r(coord))
+
+        for value in getattr(obj, "__dict__", {}).values():
+            _walk(value)
+
+    _walk(table)
 
 
 
@@ -4365,15 +4409,6 @@ def merge_fonts(config: dict) -> str:
     output_upm = int(output.get("upm") or jp_source_upm)
     jp_upm_ratio = output_upm / jp_source_upm
 
-    # Scale the JP-origin GPOS lookups by the UPM ratio now, before any Latin
-    # lookups are merged in. Latin lookups merged later are scaled separately
-    # via final_lat_scale inside merge_feature_tables.
-    if jp_upm_ratio != 1.0:
-        _gpos = merged.get("GPOS")
-        if _gpos is not None and _gpos.table and _gpos.table.LookupList:
-            for _lk in _gpos.table.LookupList.Lookup:
-                _scale_gpos_lookup(_lk, jp_upm_ratio, 0)
-
     # Output format always mirrors the base font (CFF base → CFF out,
     # TT base → TT out). This avoids TT↔CFF round-trips that would either
     # drop CFF hints or bloat point counts through cu2qu conversion.
@@ -4412,6 +4447,15 @@ def merge_fonts(config: dict) -> str:
     # the JP outlines / hints / hmtx produces output-UPM-ready values.
     jp_scale_eff = jp_scale * jp_upm_ratio
     jp_baseline_eff = jp_baseline * jp_upm_ratio
+
+    # Scale JP-origin GPOS lookups by the same transform used for JP outlines
+    # before any Latin lookups are merged in. Latin lookups merged later are
+    # scaled separately via final_lat_scale inside merge_feature_tables.
+    if jp_scale_eff != 1.0 or jp_baseline_eff != 0:
+        _gpos = merged.get("GPOS")
+        if _gpos is not None and _gpos.table and _gpos.table.LookupList:
+            for _lk in _gpos.table.LookupList.Lookup:
+                _scale_gpos_lookup(_lk, jp_scale_eff, jp_baseline_eff)
 
     if not lat_font:
         progress("merging-glyphs", 4, f"2/{S} \u00b7 Merging glyphs...")

--- a/python/tests/test_glyph_data.py
+++ b/python/tests/test_glyph_data.py
@@ -17,6 +17,87 @@ from conftest import (
 import merge_fonts as mf
 
 
+def _base_coordinates(font):
+    """Collect BASE table coordinate values in traversal order."""
+    if "BASE" not in font:
+        return []
+    coords = []
+    seen = set()
+
+    def _walk(obj):
+        if obj is None:
+            return
+        if isinstance(obj, (str, bytes, int, float, bool)):
+            return
+        if isinstance(obj, (list, tuple)):
+            for item in obj:
+                _walk(item)
+            return
+
+        obj_id = id(obj)
+        if obj_id in seen:
+            return
+        seen.add(obj_id)
+
+        if hasattr(obj, "Coordinate"):
+            coord = getattr(obj, "Coordinate")
+            if isinstance(coord, int):
+                coords.append(coord)
+
+        for value in getattr(obj, "__dict__", {}).values():
+            _walk(value)
+
+    _walk(font["BASE"].table)
+    return coords
+
+
+_GPOS_VALUE_ATTRS = ("XPlacement", "YPlacement", "XAdvance", "YAdvance")
+
+
+def _value_record_tuple(value_record):
+    return tuple(getattr(value_record, attr, None) for attr in _GPOS_VALUE_ATTRS)
+
+
+def _scaled_value_tuples(values, ratio):
+    return [
+        tuple(None if v is None else int(round(v * ratio)) for v in record)
+        for record in values
+    ]
+
+
+def _single_pos_values_for_feature(font, feature_tag, glyph_name):
+    """Return SinglePos ValueRecords for glyph_name under a GPOS feature."""
+    if "GPOS" not in font:
+        return []
+    table = font["GPOS"].table
+    if not table.FeatureList or not table.LookupList:
+        return []
+
+    values = []
+    for feature_record in table.FeatureList.FeatureRecord:
+        if feature_record.FeatureTag != feature_tag:
+            continue
+        for lookup_index in feature_record.Feature.LookupListIndex:
+            lookup = table.LookupList.Lookup[lookup_index]
+            for subtable in lookup.SubTable:
+                st = (subtable.ExtSubTable
+                      if hasattr(subtable, "ExtSubTable") else subtable)
+                coverage = getattr(st, "Coverage", None)
+                value = getattr(st, "Value", None)
+                if coverage is None or value is None:
+                    continue
+                if glyph_name not in coverage.glyphs:
+                    continue
+                glyph_index = coverage.glyphs.index(glyph_name)
+                if isinstance(value, (list, tuple)):
+                    if glyph_index >= len(value):
+                        continue
+                    values.append(_value_record_tuple(value[glyph_index]))
+                else:
+                    values.append(_value_record_tuple(value))
+    return values
+
+
 # ---------------------------------------------------------------------------
 # Variable Font instantiation
 # ---------------------------------------------------------------------------
@@ -1707,6 +1788,152 @@ class TestOutputUpm:
         ratio = 2000 / m1["head"].unitsPerEm
         assert abs(m2["OS/2"].sTypoAscender - m1["OS/2"].sTypoAscender * ratio) <= 2
         assert abs(m2["hhea"].ascent - m1["hhea"].ascent * ratio) <= 2
+
+    def test_base_table_scaled_by_upm_ratio(self):
+        m1 = _merge()
+        m2 = _merge(output_upm=2048)
+        ratio = 2048 / m1["head"].unitsPerEm
+
+        source_coords = _base_coordinates(m1)
+        output_coords = _base_coordinates(m2)
+
+        assert source_coords, "fixture should contain a BASE table"
+        assert len(output_coords) == len(source_coords)
+        assert output_coords == [int(round(v * ratio)) for v in source_coords]
+
+    def test_cff_base_table_scaled_by_upm_ratio(self):
+        out = tempfile.mktemp(suffix=".otf")
+        config = {
+            "subFont": {
+                "path": EN_CFF,
+                "scale": 1.0,
+                "baselineOffset": 0,
+                "axes": [],
+            },
+            "baseFont": {
+                "path": JP_OTF,
+                "scale": 1.0,
+                "baselineOffset": 0,
+                "axes": [],
+            },
+            "output": {"familyName": "Test", "upm": 2048},
+            "export": {"path": {"font": out}},
+        }
+        source = TTFont(JP_OTF)
+        m = None
+        try:
+            mf.merge_fonts(config)
+            m = TTFont(out)
+            ratio = 2048 / source["head"].unitsPerEm
+
+            source_coords = _base_coordinates(source)
+            output_coords = _base_coordinates(m)
+
+            assert source_coords, "fixture should contain a BASE table"
+            assert len(output_coords) == len(source_coords)
+            assert output_coords == [
+                int(round(v * ratio)) for v in source_coords
+            ]
+        finally:
+            source.close()
+            if m is not None:
+                m.close()
+            if os.path.exists(out):
+                os.remove(out)
+
+    def test_base_only_gpos_singlepos_values_scaled_by_upm_ratio(self):
+        out = tempfile.mktemp(suffix=".ttf")
+        base_cfg = {
+            "path": JP_VAR,
+            "scale": 1.0,
+            "baselineOffset": 0,
+            "axes": [{"tag": "wght", "currentValue": 400}],
+        }
+        config = {
+            "subFont": None,
+            "baseFont": base_cfg,
+            "output": {"familyName": "Test", "upm": 2048},
+            "export": {"path": {"font": out}},
+        }
+        source = TTFont(JP_VAR)
+        source = mf._instantiate_if_variable(source, base_cfg, "Test source")
+        m = None
+        try:
+            mf.merge_fonts(config)
+            m = TTFont(out)
+            ratio = 2048 / source["head"].unitsPerEm
+
+            for feature_tag, glyph_name in (
+                ("palt", "uni3042"),      # SinglePos Format 2
+                ("vpal", "glyph00209"),  # SinglePos Format 1
+                ("vpal", "glyph00216"),  # SinglePos Format 2
+            ):
+                source_values = _single_pos_values_for_feature(
+                    source, feature_tag, glyph_name
+                )
+                output_values = _single_pos_values_for_feature(
+                    m, feature_tag, glyph_name
+                )
+                assert source_values, f"{feature_tag} {glyph_name} missing"
+                assert output_values == _scaled_value_tuples(
+                    source_values, ratio
+                )
+        finally:
+            source.close()
+            if m is not None:
+                m.close()
+            if os.path.exists(out):
+                os.remove(out)
+
+    def test_base_only_gpos_singlepos_uses_base_scale_with_upm(self):
+        out = tempfile.mktemp(suffix=".ttf")
+        base_cfg = {
+            "path": JP_VAR,
+            "scale": 0.5,
+            "baselineOffset": 0,
+            "axes": [{"tag": "wght", "currentValue": 400}],
+        }
+        config = {
+            "subFont": None,
+            "baseFont": base_cfg,
+            "output": {"familyName": "Test", "upm": 2048},
+            "export": {"path": {"font": out}},
+        }
+        source = TTFont(JP_VAR)
+        source = mf._instantiate_if_variable(source, base_cfg, "Test source")
+        m = None
+        try:
+            mf.merge_fonts(config)
+            m = TTFont(out)
+            effective_scale = base_cfg["scale"] * (
+                2048 / source["head"].unitsPerEm
+            )
+
+            assert m["hmtx"].metrics["uni3042"][0] == int(round(
+                source["hmtx"].metrics["uni3042"][0] * effective_scale
+            ))
+
+            for feature_tag, glyph_name in (
+                ("palt", "uni3042"),      # SinglePos Format 2
+                ("vpal", "glyph00209"),  # SinglePos Format 1
+                ("vpal", "glyph00216"),  # SinglePos Format 2
+            ):
+                source_values = _single_pos_values_for_feature(
+                    source, feature_tag, glyph_name
+                )
+                output_values = _single_pos_values_for_feature(
+                    m, feature_tag, glyph_name
+                )
+                assert source_values, f"{feature_tag} {glyph_name} missing"
+                assert output_values == _scaled_value_tuples(
+                    source_values, effective_scale
+                )
+        finally:
+            source.close()
+            if m is not None:
+                m.close()
+            if os.path.exists(out):
+                os.remove(out)
 
     def test_base_only_respects_upm(self):
         out = tempfile.mktemp(suffix=".ttf")


### PR DESCRIPTION
## Summary

- scale BASE table coordinates when output.upm changes so vertical writing baselines stay on the target UPM grid
- scale SinglePos Format 2 GPOS ValueRecord arrays so palt/vpal values do not remain on the source UPM grid
- scale JP-origin GPOS lookups with the full JP transform, including baseFont.scale and baselineOffset, so palt/vpal values and anchors stay aligned with scaled base glyphs
- add TTF/CFF regression coverage for BASE scaling, base-only palt/vpal scaling, and baseFont.scale + output.upm interactions

Fixes #34.

## Validation

- python3 -m pytest python/tests/test_glyph_data.py::TestOutputUpm -q -> 11 passed
- python3 -m pytest python/tests/test_glyph_data.py::TestGPOSScaling python/tests/test_glyph_data.py::TestLatinKernPreservation -q -> 69 passed
- python3 -m pytest python/tests/ -q -> 551 passed, 1 skipped
