### PR TITLE
[codex] Omit empty optional name records

### DIFF
--- a/python/merge_fonts.py
+++ b/python/merge_fonts.py
@@ -3283,6 +3283,25 @@ _IDENTITY_NAMEID_LIMIT = 256
 # identity (weight class, italic bit, width class). Touched as a unit so
 # nameID 2 / 4 / 6 / 17 stay internally consistent.
 _VALID_METADATA_MODES = ("merge", "inheritBase", "inheritSub")
+_OPTIONAL_NAME_IDS = frozenset({
+    7,   # Trademark
+    8,   # Manufacturer
+    9,   # Designer
+    10,  # Description
+    11,  # Vendor URL
+    12,  # Designer URL
+    13,  # License Description
+    14,  # License Info URL
+    19,  # Sample text
+})
+_REQUIRED_NAME_IDS = frozenset({
+    1,  # Font Family
+    2,  # Font Subfamily
+    3,  # Unique font identifier
+    4,  # Full font name
+    5,  # Version string
+    6,  # PostScript name
+})
 
 
 def _resolve_metadata_mode(output: dict, has_sub_font: bool) -> str:
@@ -3315,8 +3334,24 @@ def _get_name(font: "TTFont", nameID: int) -> str:
     return nt.getDebugName(nameID) or ""
 
 
+def _is_empty_name_value(value) -> bool:
+    return value is None or str(value).strip() == ""
+
+
+def _remove_name_id(name_table, nameID: int) -> None:
+    name_table.removeNames(nameID=nameID)
+
+
 def _set_name(name_table, nameID: int, value: str):
     """Set *nameID* on Windows-Unicode platform. Mac-Roman is skipped for non-ASCII values."""
+    if _is_empty_name_value(value):
+        if nameID in _REQUIRED_NAME_IDS:
+            raise ValueError(f"Required nameID {nameID} is empty")
+        if nameID in _OPTIONAL_NAME_IDS:
+            _remove_name_id(name_table, nameID)
+        return
+
+    value = str(value)
     name_table.setName(value, nameID, 3, 1, 0x0409)   # Windows, Unicode BMP, English
     try:
         value.encode("mac_roman")
@@ -3332,9 +3367,62 @@ def _override_name(name_table, nameID: int, value: str):
     platform/encoding/language combinations the source font already had,
     instead of leaving stale Mac-Japanese / Unicode-only records behind.
     """
-    name_table.removeNames(nameID=nameID)
-    if value:
-        _set_name(name_table, nameID, value)
+    if _is_empty_name_value(value):
+        if nameID in _REQUIRED_NAME_IDS:
+            raise ValueError(f"Required nameID {nameID} is empty")
+        _remove_name_id(name_table, nameID)
+        return
+
+    _remove_name_id(name_table, nameID)
+    _set_name(name_table, nameID, value)
+
+
+def _prune_empty_optional_name_records(font: TTFont) -> int:
+    """Remove optional name records whose decoded text is empty."""
+    name_table = font.get("name")
+    if not name_table:
+        return 0
+
+    kept = []
+    removed = 0
+    for record in name_table.names:
+        if record.nameID in _OPTIONAL_NAME_IDS:
+            try:
+                if _is_empty_name_value(record.toUnicode()):
+                    removed += 1
+                    continue
+            except Exception:
+                pass
+        kept.append(record)
+    name_table.names = kept
+    return removed
+
+
+def _validate_required_name_records_non_empty(font: TTFont) -> None:
+    """Ensure core identity records exist and contain non-whitespace text."""
+    name_table = font.get("name")
+    if not name_table:
+        raise ValueError("Missing name table")
+
+    by_id = {}
+    for record in name_table.names:
+        if record.nameID in _REQUIRED_NAME_IDS:
+            by_id.setdefault(record.nameID, []).append(record)
+
+    for nameID in sorted(_REQUIRED_NAME_IDS):
+        records = by_id.get(nameID, [])
+        if not records:
+            raise ValueError(f"Missing required nameID {nameID}")
+        has_non_empty_record = False
+        for record in records:
+            try:
+                if not _is_empty_name_value(record.toUnicode()):
+                    has_non_empty_record = True
+                    break
+            except Exception:
+                continue
+        if not has_non_empty_record:
+            raise ValueError(f"Required nameID {nameID} is empty")
 
 
 def _set_ofl_metadata(lat_font, jp_font, merged, config: dict):
@@ -4112,6 +4200,9 @@ def reconcile_tables(lat_font: TTFont, jp_font: TTFont, merged: TTFont, config: 
                         nid = getattr(fp, attr, None)
                         if nid in nameid_remap:
                             setattr(fp, attr, nameid_remap[nid])
+
+    _prune_empty_optional_name_records(merged)
+    _validate_required_name_records_non_empty(merged)
 
     # --- OS/2 ---
     if not lat_font:

--- a/python/tests/test_metadata.py
+++ b/python/tests/test_metadata.py
@@ -12,6 +12,15 @@ from conftest import EN_CFF_FULL, EN_VAR, JP_VAR, _merge, _merge_with_meta
 import merge_fonts as mf
 
 
+def _name_values(font, name_id):
+    values = []
+    for record in font["name"].names:
+        if record.nameID != name_id:
+            continue
+        values.append(record.toUnicode())
+    return values
+
+
 # ---------------------------------------------------------------------------
 # Output weight / nameID 2, 4, 17
 # ---------------------------------------------------------------------------
@@ -422,13 +431,15 @@ class TestMetadataCorrectness:
         """nameID 9 is always cleared — Designer belongs to the source authors."""
         m = _merge_with_meta()
         d = m["name"].getDebugName(9)
-        assert d is None or d == "", f"Expected cleared designer, got '{d}'"
+        assert d is None, f"Expected omitted designer, got '{d}'"
+        assert _name_values(m, 9) == []
 
     def test_designer_url_always_cleared(self):
         """nameID 12 is always cleared — Designer URL is not set on the derivative."""
         m = _merge_with_meta()
         url = m["name"].getDebugName(12)
-        assert url is None or url == "", f"Expected cleared designer URL, got '{url}'"
+        assert url is None, f"Expected omitted designer URL, got '{url}'"
+        assert _name_values(m, 12) == []
 
     def test_manufacturer_set_when_provided(self):
         """outputManufacturer is written to nameID 8."""
@@ -439,7 +450,8 @@ class TestMetadataCorrectness:
         """Missing outputManufacturer clears nameID 8."""
         m = _merge_with_meta(output_manufacturer="")
         v = m["name"].getDebugName(8)
-        assert v is None or v == "", f"Expected empty manufacturer, got '{v}'"
+        assert v is None, f"Expected omitted manufacturer, got '{v}'"
+        assert _name_values(m, 8) == []
 
     def test_manufacturer_url_set_when_provided(self):
         """outputManufacturerURL is written to nameID 11."""
@@ -450,7 +462,14 @@ class TestMetadataCorrectness:
         """Missing outputManufacturerURL clears nameID 11."""
         m = _merge_with_meta(output_manufacturer_url="")
         url = m["name"].getDebugName(11)
-        assert url is None or url == "", f"Expected empty manufacturer URL, got '{url}'"
+        assert url is None, f"Expected omitted manufacturer URL, got '{url}'"
+        assert _name_values(m, 11) == []
+
+    def test_whitespace_optional_metadata_is_omitted(self):
+        m = _merge_with_meta(output_manufacturer=" \t ",
+                             output_manufacturer_url="\n")
+        assert _name_values(m, 8) == []
+        assert _name_values(m, 11) == []
 
     def test_vendor_id_always_four_spaces(self):
         """OS/2 achVendID is fixed to 4 spaces (unknown vendor)."""
@@ -588,7 +607,8 @@ class TestMetadataBaseOnly:
         """Base-only merges also clear nameID 9 — Designer is never set on the output."""
         m = self._merge_base_only_meta()
         d = m["name"].getDebugName(9)
-        assert d is None or d == "", f"Expected cleared designer, got '{d}'"
+        assert d is None, f"Expected omitted designer, got '{d}'"
+        assert _name_values(m, 9) == []
 
     def test_description_mentions_built_with(self):
         """Base-only also uses 'Built with OFL Font Baker' in nameID 10."""
@@ -735,6 +755,18 @@ class TestMetadataModeValidation:
         m = _merge_inherit(None, output_extra={"familyName": "MergedNull"})
         assert m["name"].getDebugName(1) == "MergedNull"
 
+    def test_missing_required_name_record_raises(self):
+        font = TTFont(JP_VAR)
+        font["name"].removeNames(nameID=1)
+        with pytest.raises(ValueError, match="Missing required nameID 1"):
+            mf._validate_required_name_records_non_empty(font)
+
+    def test_empty_required_name_record_raises(self):
+        font = TTFont(JP_VAR)
+        font["name"].setName("", 1, 3, 1, 0x0409)
+        with pytest.raises(ValueError, match="Required nameID 1 is empty"):
+            mf._validate_required_name_records_non_empty(font)
+
 
 class TestInheritBase:
     """inheritBase: pass identity through from the base font."""
@@ -760,6 +792,35 @@ class TestInheritBase:
         m = _merge_inherit("inheritBase")
         if base_designer:
             assert m["name"].getDebugName(9) == base_designer
+
+    def test_empty_optional_records_pruned_from_inherited_source(self):
+        """inherit mode preserves non-empty source metadata, but not empty optional records."""
+        base_path = tempfile.mktemp(suffix=".ttf")
+        out = tempfile.mktemp(suffix=".ttf")
+        base = TTFont(JP_VAR)
+        base["name"].setName("", 9, 3, 1, 0x0409)
+        base["name"].setName("   ", 12, 3, 1, 0x0409)
+        base.save(base_path)
+
+        config = {
+            "baseFont": {
+                "path": base_path,
+                "scale": 1.0,
+                "baselineOffset": 0,
+                "axes": [{"tag": "wght", "currentValue": 400}],
+            },
+            "output": {"metadataMode": "inheritBase"},
+            "export": {"path": {"font": out}},
+        }
+        try:
+            mf.merge_fonts(config)
+            m = TTFont(out)
+            assert _name_values(m, 9) == []
+            assert _name_values(m, 12) == []
+        finally:
+            for f in (base_path, out, out.replace(".ttf", ".woff2")):
+                if os.path.exists(f):
+                    os.remove(f)
 
     def test_license_not_forced_to_ofl_canonical(self):
         """inherit mode does NOT overwrite nameID 13 with the canonical OFL text."""


### PR DESCRIPTION
## Summary

- Treat empty or whitespace-only optional OpenType `name` values as omitted records instead of zero-length strings.
- Add a final cleanup pass for inherited empty optional records and validate required identity name records are present and non-empty.
- Update metadata tests to assert Designer, Designer URL, Manufacturer, and Manufacturer URL records are absent when cleared.

## Why

macOS Font Book can warn on generated fonts that contain empty optional `name` table records such as Designer (`nameID 9`) and Designer URL (`nameID 12`). Optional metadata fields should be represented by absence when no meaningful value is provided.

## Validation

- `python3 -m pytest python/tests/test_metadata.py -q` -> 128 passed
- `git diff --check` -> passed

Note: broader Python test runs were intentionally not used for validation here; the heavy suite was skipped as requested.